### PR TITLE
[Refactor][RIUI-1617]: Introducing process.env log messeges for user

### DIFF
--- a/api/local.ts
+++ b/api/local.ts
@@ -53,8 +53,25 @@ app.use(auth.attach)
 
 app.use('/api', routes)
 
+// const port = process.env.PORT || 3000
+// app.listen(port)
+
 const port = process.env.PORT || 3000
-app.listen(port)
+app.listen(port, () => {
+  // process.env,
+  console.log('app process env S2S_SECRET key is:', process.env.S2S_SECRET )
+  console.log('app process env IDAM_SECRET key is:', process.env.IDAM_SECRET )
+  if (process.env.S2S_SECRET === undefined  ) {
+    console.log('Your are missing a S2S_SECRET, please read README file')
+    process.exit()
+  }
+  if (process.env.IDAM_SECRET === undefined ) {
+    console.log('Your are missing a IDAM_SECRET, please read README file')
+    process.exit()
+  }
+  console.log('App running on' + port)
+});
+
 
 if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
     config.appInsightsInstrumentationKey = process.env.APPINSIGHTS_INSTRUMENTATIONKEY

--- a/api/server.ts
+++ b/api/server.ts
@@ -68,5 +68,10 @@ app.use('/*', (req, res) => {
 if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
     config.appInsightsInstrumentationKey = process.env.APPINSIGHTS_INSTRUMENTATIONKEY
 }
+console.log('HERE WE GO', )
 
-app.listen(process.env.PORT || 3000)
+const port = process.env.PORT || 3000
+app.listen(port, () => {
+  console.log('app process env', process.env)
+  console.log('App running on' + port)
+});


### PR DESCRIPTION
Introduce in the API process when booting the app to give the user better messaging if they are missing Process environment keys based on ticket: https://tools.hmcts.net/jira/browse/RIUI-1617