### PR TITLE
DO NOT MERGE - CAB candidate: Feature/EUI 727 dx example and validation

### DIFF
--- a/src/register/constants/organisationDx.ts
+++ b/src/register/constants/organisationDx.ts
@@ -9,13 +9,13 @@ export const organisationDx = {
       {
         validationLevel: 'formControl',
         controlId: 'DXnumber',
-        text: 'Enter valid DX number.',
+        text: 'Enter valid DX number',
         href: '/register/organisation-name',
       },
       {
         validationLevel: 'formControl',
         controlId: 'DXexchange',
-        text: 'Enter valid DX exchange.',
+        text: 'Enter valid DX exchange',
         href: '/register/organisation-name',
       }
     ],

--- a/src/register/constants/organisationDx.ts
+++ b/src/register/constants/organisationDx.ts
@@ -9,13 +9,13 @@ export const organisationDx = {
       {
         validationLevel: 'formControl',
         controlId: 'DXnumber',
-        text: 'Enter DX number. It must be 13 characters',
+        text: 'Enter DX number.',
         href: '/register/organisation-name',
       },
       {
         validationLevel: 'formControl',
         controlId: 'DXexchange',
-        text: 'Enter DX exchange. It can be up to 20 characters',
+        text: 'Enter DX exchange.',
         href: '/register/organisation-name',
       }
     ],
@@ -27,9 +27,9 @@ export const organisationDx = {
             classes: 'govuk-label--m',
           },
           control: 'DXnumber',
-          validators: ['dxNumberExactLength'],
+          validators: ['dxNumberMaxLength'],
           validationError: {
-            value: 'Enter DX number. It must be 13 characters',
+            value: 'This can be up to 13 characters (including letters and numbers). For example 931NR. You don\'t need to include \'DX\'',
             controlId: 'DXnumber',
           },
           classes: 'govuk-!-width-two-thirds',
@@ -44,7 +44,7 @@ export const organisationDx = {
           control: 'DXexchange',
           validators: ['dxExchangeMaxLength'],
           validationError: {
-            value: 'Enter DX exchange. It can be up to 20 characters',
+            value: 'This can be up to 20 characters (including letters, numbers and symbols). For example: HAYES (MIDDLESEX).',
             controlId: 'DXexchange',
           },
           classes: 'govuk-!-width-two-thirds',

--- a/src/register/constants/organisationDx.ts
+++ b/src/register/constants/organisationDx.ts
@@ -9,13 +9,13 @@ export const organisationDx = {
       {
         validationLevel: 'formControl',
         controlId: 'DXnumber',
-        text: 'Enter DX number.',
+        text: 'Enter valid DX number.',
         href: '/register/organisation-name',
       },
       {
         validationLevel: 'formControl',
         controlId: 'DXexchange',
-        text: 'Enter DX exchange.',
+        text: 'Enter valid DX exchange.',
         href: '/register/organisation-name',
       }
     ],
@@ -26,10 +26,14 @@ export const organisationDx = {
             text: 'DX number',
             classes: 'govuk-label--m',
           },
+          hint: {
+            text: 'This can be up to 13 characters (including letters and numbers). For example 931NR. You don\'t need to include \'DX\'.',
+            classes: 'govuk-hint'
+          },
           control: 'DXnumber',
           validators: ['dxNumberMaxLength'],
           validationError: {
-            value: 'This can be up to 13 characters (including letters and numbers). For example 931NR. You don\'t need to include \'DX\'',
+            value: 'Enter valid DX number',
             controlId: 'DXnumber',
           },
           classes: 'govuk-!-width-two-thirds',
@@ -41,10 +45,14 @@ export const organisationDx = {
             text: 'DX exchange',
             classes: 'govuk-label--m',
           },
+          hint: {
+            text: 'This can be up to 20 characters (including letters, numbers and symbols). For example: HAYES (MIDDLESEX).',
+            classes: 'govuk-hint'
+          },
           control: 'DXexchange',
           validators: ['dxExchangeMaxLength'],
           validationError: {
-            value: 'This can be up to 20 characters (including letters, numbers and symbols). For example: HAYES (MIDDLESEX).',
+            value: 'Enter valid DX exchange',
             controlId: 'DXexchange',
           },
           classes: 'govuk-!-width-two-thirds',

--- a/src/register/containers/hmcts-form-builder/src/lib/services/form-builder-validation.service.ts
+++ b/src/register/containers/hmcts-form-builder/src/lib/services/form-builder-validation.service.ts
@@ -35,6 +35,10 @@ export class ValidationService {
       ngValidatorFunction: this.customValidatorService.exactLengthValidator(13)
     },
     {
+      simpleName: 'dxNumberMaxLength',
+      ngValidatorFunction: Validators.maxLength(13)
+    },
+    {
       simpleName: 'dxExchangeMaxLength',
       ngValidatorFunction: Validators.maxLength(20)
     },


### PR DESCRIPTION
- Changes to validation as per EUI-727, this meant the removal of the hard 13 character length for DX number to a more relaxed max length of 13 characters.
- Addition of a hint above the text input to display
'This can be up to 13 characters (including letters and numbers). For example 931NR. You don't need to include 'DX' for DX Number.
and 
'This can be up to 20 characters (including letters, numbers and symbols). For example: HAYES (MIDDLESEX).' for DX Exchange.

- [ x] commit messages are meaningful.
- [ x] no new documentation needed
- [ x] no new tests needed.

### JIRA link ###
https://tools.hmcts.net/jira/browse/EUI-727

### Change description ###

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
