### PR TITLE
AWAITING CAB: Restrict access to only Manage Organisation Users.

### DIFF
--- a/api/auth/index.ts
+++ b/api/auth/index.ts
@@ -8,6 +8,7 @@ import { EnhancedRequest } from '../lib/models'
 import { asyncReturnOrError } from '../lib/util'
 import { getUserDetails } from '../services/idam'
 import { serviceTokenGenerator } from './serviceToken'
+import { userHasAppAccess } from './userRoleAuth'
 
 const secret = process.env.IDAM_SECRET
 const logger = log4js.getLogger('auth')
@@ -81,9 +82,16 @@ async function sessionChainCheck(req: EnhancedRequest, res: express.Response, ac
     if (!req.session.auth) {
         logger.warn('Session expired. Trying to get user details again')
         console.log(getUserDetails(accessToken, idamUrl))
-        const details = await asyncReturnOrError(getUserDetails(accessToken, idamUrl), 'Cannot get user details', res, logger, false)
+        const userDetails = await asyncReturnOrError(getUserDetails(accessToken, idamUrl), 'Cannot get user details', res, logger, false)
 
-        if (details) {
+
+      if (!userHasAppAccess(userDetails.data.roles)) {
+          logger.warn('User has no application access, as they do not have a Manage Organisations role.')
+          doLogout(req, res, 401)
+          return false
+        }
+
+        if (userDetails) {
             logger.info('Setting session')
             const orgIdResponse = {
                 data: {
@@ -91,11 +99,11 @@ async function sessionChainCheck(req: EnhancedRequest, res: express.Response, ac
                 },
             }
             req.session.auth = {
-                email: details.data.email,
+                email: userDetails.data.email,
                 orgId: orgIdResponse.data.id,
-                roles: details.data.roles,
+                roles: userDetails.data.roles,
                 token: accessToken,
-                userId: details.data.id,
+                userId: userDetails.data.id,
             }
         }
     }

--- a/api/auth/userRoleAuth.spec.ts
+++ b/api/auth/userRoleAuth.spec.ts
@@ -1,0 +1,114 @@
+import {expect} from 'chai'
+import {
+  hasManageOrganisationRole,
+  hasPuiCaseManagerRole,
+  MANAGE_ORGANISATION_ROLES,
+  PUI_CASE_MANAGER,
+  userHasAppAccess
+} from './userRoleAuth'
+
+describe('userRoleAuthentication', () => {
+
+  it('Should return true if a User has a Pui Case Manager Role and a Manage Organisation role.', () => {
+
+    const roles = [
+      'pui-case-manager',
+      'pui-user-manager',
+      'caseworker',
+    ]
+
+    expect(userHasAppAccess(roles)).to.be.true
+  })
+
+  it('Should return false if a User only has a Pui Case Manager Role.', () => {
+
+    const roles = [
+      'pui-case-manager',
+      'caseworker',
+    ]
+
+    expect(userHasAppAccess(roles)).to.be.false
+  })
+
+  it('Should return false if a User only has a Manage Organisation Role.', () => {
+
+    const roles = [
+      'pui-user-manager',
+    ]
+
+    expect(userHasAppAccess(roles)).to.be.false
+  })
+
+  it('Should return false if a User only has no roles.', () => {
+
+    const roles = []
+
+    expect(userHasAppAccess(roles)).to.be.false
+  })
+
+  it('Should return true if there is a \'pui-case-manager\' role.', () => {
+
+    const roles = [
+      'pui-case-manager',
+      'caseworker',
+    ]
+
+    expect(hasPuiCaseManagerRole(roles)).to.be.true
+  })
+
+  it('Should return false if there is no \'pui-case-manager\' role.', () => {
+
+    const roles = [
+      'caseworker',
+    ]
+
+    expect(hasPuiCaseManagerRole(roles)).to.be.false
+  })
+
+  /**
+   * If the User has a Manage Organisation role, and a Pui Case Manager role
+   * then we should allow the User access to the Manage Organisations application.
+   */
+  it('Should return true if there is a Manage Organisation role, as part of a User\'s roles.', () => {
+
+    const roles = [
+      'caseworker',
+      'pui-organisation-manager',
+    ]
+
+    const manageOrganisationRoles = [
+      'pui-organisation-manager',
+      'pui-user-manager',
+      'pui-finance-manager',
+    ]
+
+    expect(hasManageOrganisationRole(roles, manageOrganisationRoles)).to.be.true
+  })
+
+  it('Should return false if there is no Manage Organisation role, as part of a User\'s roles.', () => {
+
+    const roles = [
+      'caseworker',
+    ]
+
+    const manageOrganisationRoles = [
+      'pui-organisation-manager',
+      'pui-user-manager',
+      'pui-finance-manager',
+    ]
+
+    expect(hasManageOrganisationRole(roles, manageOrganisationRoles)).to.be.false
+  })
+
+  it('Should have the correct Manage Organisation Roles', () => {
+    expect(MANAGE_ORGANISATION_ROLES).to.be.deep.equal([
+      'pui-organisation-manager',
+      'pui-user-manager',
+      'pui-finance-manager',
+    ])
+  })
+
+  it('Should have the correct Pui Case Manager Role', () => {
+    expect(PUI_CASE_MANAGER).to.be.deep.equal('pui-case-manager')
+  })
+})

--- a/api/auth/userRoleAuth.spec.ts
+++ b/api/auth/userRoleAuth.spec.ts
@@ -20,7 +20,7 @@ describe('userRoleAuthentication', () => {
     expect(userHasAppAccess(roles)).to.be.true
   })
 
-  it('Should return false if a User only has a Pui Case Manager Role.', () => {
+  it('Should return false if a User has a Pui Case Manager Role, without a Manage Organisations Role.', () => {
 
     const roles = [
       'pui-case-manager',
@@ -30,13 +30,16 @@ describe('userRoleAuthentication', () => {
     expect(userHasAppAccess(roles)).to.be.false
   })
 
-  it('Should return false if a User only has a Manage Organisation Role.', () => {
+  /**
+   * We should be allowing the User to get into the application if the User has a Manage Organisation Role.
+   */
+  it('Should return true if a User has a Manage Organisation Role, without a Pui Case Manager Role.', () => {
 
     const roles = [
       'pui-user-manager',
     ]
 
-    expect(userHasAppAccess(roles)).to.be.false
+    expect(userHasAppAccess(roles)).to.be.true
   })
 
   it('Should return false if a User only has no roles.', () => {

--- a/api/auth/userRoleAuth.ts
+++ b/api/auth/userRoleAuth.ts
@@ -25,7 +25,7 @@ export const PUI_CASE_MANAGER = 'pui-case-manager'
  */
 export function userHasAppAccess(roles) {
 
-  return hasPuiCaseManagerRole(roles) && hasManageOrganisationRole(roles, MANAGE_ORGANISATION_ROLES)
+  return hasManageOrganisationRole(roles, MANAGE_ORGANISATION_ROLES)
 }
 
 /**

--- a/api/auth/userRoleAuth.ts
+++ b/api/auth/userRoleAuth.ts
@@ -1,0 +1,52 @@
+/**
+ * These are static roles assigned to Manage Organisation User.
+ */
+export const MANAGE_ORGANISATION_ROLES = [
+  'pui-organisation-manager',
+  'pui-user-manager',
+  'pui-finance-manager',
+]
+
+/**
+ * These are static roles assigned to Manage Organisation User.
+ */
+export const PUI_CASE_MANAGER = 'pui-case-manager'
+
+/**
+ * User Has Application Access
+ *
+ * We check that a User has access to the Manage Organisations application; they need to have both a
+ * pui-case-manager role and a manage organisations role as per business requirements to have access.
+ *
+ * If the User only has a pui-case-manager role, they should not be allowed to access the application.
+ *
+ * @see EUI-836
+ * @param roles - @see unit
+ */
+export function userHasAppAccess(roles) {
+
+  return hasPuiCaseManagerRole(roles) && hasManageOrganisationRole(roles, MANAGE_ORGANISATION_ROLES)
+}
+
+/**
+ * Checks if a User has a pui-case-manager role
+ *
+ * @param roles - @see unit
+ */
+export function hasPuiCaseManagerRole(roles) {
+
+  return roles.includes(PUI_CASE_MANAGER)
+}
+
+/**
+ * Check if a User has a Manage Organisational role.
+ *
+ * @param roles - @see unit
+ * @param manageOrganisationRoles - @see unit
+ */
+export function hasManageOrganisationRole(roles, manageOrganisationRoles) {
+
+  const intersectingRoles = manageOrganisationRoles.filter(manageOrganisationRole => roles.includes(manageOrganisationRole))
+
+  return intersectingRoles.length > 0
+}

--- a/api/lib/objectUtilities.spec.ts
+++ b/api/lib/objectUtilities.spec.ts
@@ -1,4 +1,5 @@
-import {propsExist} from './objectUtilities';
+import { expect } from 'chai'
+import { propsExist } from './objectUtilities'
 
 describe('Object Utilities ', () => {
 
@@ -8,28 +9,28 @@ describe('Object Utilities ', () => {
 
       const object = {level1: {level2: {level3: 'level3'}}}
 
-      expect(propsExist(object, ['level1', 'level2', 'level3'])).toBeTruthy()
+      expect(propsExist(object, ['level1', 'level2', 'level3'])).to.be.true
     })
 
     it('Should return false if a property does not exist on an object.', () => {
 
       const object = {level1: {level2: {level3: 'level3'}}}
 
-      expect(propsExist(object, ['level1', 'breakingProperty', 'level3'])).toBeFalsy()
+      expect(propsExist(object, ['level1', 'breakingProperty', 'level3'])).to.be.false
     })
 
     it('Should return false if the object is undefined.', () => {
 
       const object = undefined
 
-      expect(propsExist(object, ['level1', 'level2', 'level3'])).toBeFalsy()
+      expect(propsExist(object, ['level1', 'level2', 'level3'])).to.be.false
     })
 
     it('Should return false if the object is null.', () => {
 
       const object = null
 
-      expect(propsExist(object, ['level1', 'level2', 'level3'])).toBeFalsy()
+      expect(propsExist(object, ['level1', 'level2', 'level3'])).to.be.false
     })
   })
 })

--- a/api/lib/objectUtilities.test.ts
+++ b/api/lib/objectUtilities.test.ts
@@ -1,0 +1,35 @@
+import {propsExist} from './objectUtilities';
+
+describe('Object Utilities ', () => {
+
+  describe('propsExist()', () => {
+
+    it('Should return true if all the properties exist on an object.', () => {
+
+      const object = {level1: {level2: {level3: 'level3'}}}
+
+      expect(propsExist(object, ['level1', 'level2', 'level3'])).toBeTruthy()
+    })
+
+    it('Should return false if a property does not exist on an object.', () => {
+
+      const object = {level1: {level2: {level3: 'level3'}}}
+
+      expect(propsExist(object, ['level1', 'breakingProperty', 'level3'])).toBeFalsy()
+    })
+
+    it('Should return false if the object is undefined.', () => {
+
+      const object = undefined
+
+      expect(propsExist(object, ['level1', 'level2', 'level3'])).toBeFalsy()
+    })
+
+    it('Should return false if the object is null.', () => {
+
+      const object = null
+
+      expect(propsExist(object, ['level1', 'level2', 'level3'])).toBeFalsy()
+    })
+  })
+})

--- a/api/lib/objectUtilities.ts
+++ b/api/lib/objectUtilities.ts
@@ -1,0 +1,20 @@
+/**
+ * Checks if nested properties exists on an object.
+ *
+ * Ref: https://stackoverflow.com/questions/2631001/test-for-existence-of-nested-javascript-object-key
+ *
+ * @see unit tests
+ * @param object
+ * @returns {boolean}
+ */
+export function propsExist(object, nestedProps) {
+
+  for (const nestedProperty of nestedProps) {
+    if (!object || !object.hasOwnProperty(nestedProperty)) {
+      return false
+    }
+    object = object[nestedProperty]
+  }
+
+  return true
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-836

### Change description ###
We check that a User has access to the Manage Organisations application; they need to have both a pui-case-manager role and a manage organisations role as per business requirements to have access to MO.

Currently a User with only a pui-case-manager role is able to access Manage Organisations, which should not happen.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
