### PR TITLE
Set cloudRole name in app insights

### DIFF
--- a/api/lib/appInsights.ts
+++ b/api/lib/appInsights.ts
@@ -19,6 +19,7 @@ export function initialiseAppInsights() {
     .start()
 
   client = applicationinsights.defaultClient
+  client.context.tags[client.context.keys.cloudRole] = 'xui-mo'
   client.trackTrace({ message: 'App Insight Activated' })
 }
 


### PR DESCRIPTION
So that we can differentiate the app when searching