### PR TITLE
Update contact details for FPLA

### DIFF
--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -124,9 +124,9 @@ const getHelpDetailsData: ContactDetailsDataModel[] = [
   {
     title: 'Family Public Law and Adoption',
     badgeColour: BadgeColour.BADGE_RED,
-    email: 'fpla@justice.gov.uk',
+    email: 'contactfpl@justice.gov.uk',
     phone: '0330 808 4424',
-    openingTimes: 'Monday to Friday, 8:30am to 5pm (excluding public holidays)'
+    openingTimes: 'Monday to Friday, 9am to 5pm (excluding public holidays)'
   }
 ];
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2784


### Change description ###
Change to update the Family Public Law and Adoption (FPLA) copy in the 'Get help' link in the footer.

Current copy:
Family Public Law and Adoption
Email: fpla@justice.gov.uk
Phone: 0330 808 4424
Opening times: Monday to Friday, 8:30am to 5pm (excluding public holidays)

Updated copy as part of this pull request:
Family Public Law and Adoption
Email: contactfpl@justice.gov.uk
Phone: 0330 808 4424
Opening times: Monday to Friday, 9am to 5pm (excluding public holidays)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
