### PR TITLE
Manage Organisation doesn't work on IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "govuk_frontend_toolkit": "^8.2.0",
     "git-rev-sync": "^2.0.0",
     "helmet": "^3.21.3",
+    "isomorphic-fetch": "^3.0.0",
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^8.5.1",
     "jwt-decode": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -211,6 +211,8 @@
     "@stryker-mutator/karma-runner": "^3.0.1",
     "@stryker-mutator/mocha-runner": "^3.0.1",
     "@stryker-mutator/typescript": "^3.0.1",
-    "**/**/ini": "^1.3.6"
+    "**/**/ini": "^1.3.6",
+    "**/**/prismjs": "^1.23.0",
+    "**/**/serialize-javascript": "^3.1.0"
   }
 }

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -35,6 +35,7 @@ import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
 import 'core-js/es7/object';
 import 'core-js/es7/array';
+import 'isomorphic-fetch';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6915,6 +6915,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -13167,6 +13175,11 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 when@~3.6.x:
   version "3.6.4"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3510


### Change description ###
Manage Organisation doesn't work on IE11 browser


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
