### PR TITLE
Move page titles from ngrx store to routes/ title service

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -16,17 +16,26 @@ export const ROUTES: Routes = [
   {
     path: 'organisation',
     canActivate: [AuthGuard, TermsConditionGuard, HealthCheckGuard],
-    loadChildren: '../organisation/organisation.module#OrganisationModule'
+    loadChildren: '../organisation/organisation.module#OrganisationModule',
+    data: {
+      title: 'Organisation details'
+    }
   },
   {
     path: 'users',
     canActivate: [AuthGuard, TermsConditionGuard, HealthCheckGuard],
-    loadChildren: '../users/users.module#UsersModule'
+    loadChildren: '../users/users.module#UsersModule',
+    data: {
+      title: 'Users'
+    }
   },
   {
     path: 'fee-accounts',
     canActivate: [AuthGuard, HealthCheckGuard],
-    loadChildren: '../fee-accounts/fee-accounts.module#FeeAccountsModule'
+    loadChildren: '../fee-accounts/fee-accounts.module#FeeAccountsModule',
+    data: {
+      title: 'Fee accounts'
+    }
   },
   {
     path: 'unassigned-cases',
@@ -40,16 +49,25 @@ export const ROUTES: Routes = [
   },
   {
     path: 'register-org',
-    loadChildren: '../register/register.module#RegisterModule'
+    loadChildren: '../register/register.module#RegisterModule',
+    data: {
+      title: 'Register organisation'
+    }
   },
   {
     path: 'accept-terms-and-conditions',
     canActivate: [AuthGuard, AcceptTermsAndConditionGuard],
-    loadChildren: '../accept-tc/accept-tc.module#AcceptTcModule'
+    loadChildren: '../accept-tc/accept-tc.module#AcceptTcModule',
+    data: {
+      title: 'Terms and conditions'
+    }
   },
   {
     path: 'service-down',
-    component: ServiceDownComponent
+    component: ServiceDownComponent,
+    data: {
+      title: 'Service down'
+    }
   },
   {
     canActivate: [AuthGuard],
@@ -58,23 +76,38 @@ export const ROUTES: Routes = [
   },
   {
     path: 'cookies',
-    component: CookiePolicyComponent
+    component: CookiePolicyComponent,
+    data: {
+      title: 'Cookies'
+    }
   },
   {
     path: 'privacy-policy',
-    component: PrivacyPolicyComponent
+    component: PrivacyPolicyComponent,
+    data: {
+      title: 'Privacy policy'
+    }
   },
   {
     path: 'terms-and-conditions',
-    component: TermsAndConditionsComponent
+    component: TermsAndConditionsComponent,
+    data: {
+      title: 'Terms and conditions'
+    }
   },
   {
     path: 'accessibility',
-    component: AccessibilityComponent
+    component: AccessibilityComponent,
+    data: {
+      title: 'Accessibility statement for Expert UI'
+    }
   },
   {
     path: 'get-help',
-    component: GetHelpComponent
+    component: GetHelpComponent,
+    data: {
+      title: 'Get help'
+    }
   },
   {
     path: 'idle-sign-out',

--- a/src/app/containers/app/app.component.html
+++ b/src/app/containers/app/app.component.html
@@ -8,7 +8,7 @@
 
 <a [routerLink]="" fragment="{{mainContentId}}" class="govuk-skip-link" (click)="onFocusMainContent()">Skip to main content</a>
 <app-loader></app-loader>
-<title>{{pageTitle$ | async}}</title>
+<title>HMCTS Manage organisations</title>
 
 <app-header
   [navItems]="navItems$ | async"

--- a/src/app/containers/app/app.component.spec.ts
+++ b/src/app/containers/app/app.component.spec.ts
@@ -100,13 +100,6 @@ describe('AppComponent', () => {
     fixture.detectChanges();
   }));
 
-  it('should have pageTitle$ Observable the app', async(() => {
-    const expected = cold('a', { a: '' });
-    expect(app.pageTitle$).toBeObservable(expected);
-
-  }));
-
-
   it('should have appHeaderTitle$ Observable the app', async(() => {
     const expected = cold('a', { a: undefined });
     expect(app.appHeaderTitle$).toBeObservable(expected);

--- a/src/app/store/actions/app.actions.ts
+++ b/src/app/store/actions/app.actions.ts
@@ -3,7 +3,6 @@ import { Action } from '@ngrx/store';
 import { GlobalError } from '../reducers/app.reducer';
 
 export const SET_PAGE_TITLE = '[APP] Set Page Title';
-export const SET_PAGE_TITLE_ERRORS = '[APP] Set Page Title Errors';
 export const SET_USER_ROLES = '[APP] Set User Roles';
 export const LOAD_JURISDICTIONS_GLOBAL = '[Invite User] Load Jurisdictions Global';
 export const LOAD_JURISDICTIONS_GLOBAL_SUCCESS = '[Invite User] Load Jurisdictions Global Success';
@@ -63,15 +62,6 @@ export class ClearGlobalError implements Action {
   constructor() {}
 }
 
-export class SetPageTitle implements Action {
-  public readonly type = SET_PAGE_TITLE;
-  constructor(public payload: string) {}
-}
-
-export class SetPageTitleErrors implements Action {
-  public readonly type = SET_PAGE_TITLE_ERRORS;
-}
-
 export class Logout implements Action {
   public readonly type = LOGOUT;
 }
@@ -123,8 +113,6 @@ export type appActions =
   | LoadJurisdictions
   | LoadJurisdictionsFail
   | LoadJurisdictionsSuccess
-  | SetPageTitle
-  | SetPageTitleErrors
   | Logout
   | SetUserRoles
   | LoadTermsConditions

--- a/src/app/store/effects/app.effects.spec.ts
+++ b/src/app/store/effects/app.effects.spec.ts
@@ -7,13 +7,10 @@ import { CookieService } from 'ngx-cookie';
 import { of, throwError } from 'rxjs';
 import { TermsConditionsService } from 'src/shared/services/termsConditions.service';
 import { JurisdictionService } from 'src/users/services/jurisdiction.service';
-import {ENVIRONMENT_CONFIG} from '../../../models/environmentConfig.model';
 import { LoggerService } from '../../../shared/services/logger.service';
 import {AuthService} from '../../../user-profile/services/auth.service';
 import * as fromUserProfile from '../../../user-profile/store';
-import * as usersActions from '../../../users/store/actions';
 import * as appActions from '../../store/actions';
-import { SetPageTitleErrors } from '../actions/app.actions';
 import {reducers} from '../reducers';
 import * as fromAppEffects from './app.effects';
 
@@ -67,17 +64,6 @@ describe('App Effects', () => {
     loggerService = TestBed.get(LoggerService);
 
   });
-
-  describe('updateTitle$', () => {
-    it('should update error headerTitle', () => {
-      const action = new usersActions.UpdateErrorMessages({});
-      const completion = new SetPageTitleErrors();
-      actions$ = hot('-a', { a: action });
-      const expected = cold('-b', { b: completion });
-      expect(effects.updateTitle$).toBeObservable(expected);
-    });
-  });
-
 
   describe('setUserRoles$', () => {
     it('should set user roles', () => {

--- a/src/app/store/effects/app.effects.ts
+++ b/src/app/store/effects/app.effects.ts
@@ -26,14 +26,6 @@ export class AppEffects {
   ) { }
 
   @Effect()
-  public updateTitle$ = this.actions$.pipe(
-    ofType(usersActions.UPDATE_ERROR_MESSAGES),
-    map(() => {
-      return new appActions.SetPageTitleErrors();
-    })
-  );
-
-  @Effect()
   public setUserRoles$ = this.actions$.pipe(
     ofType(fromUserProfile.AuthActionTypes.GET_USER_DETAILS_SUCCESS),
     map((actions: fromUserProfile.GetUserDetailsSuccess) => actions.payload.roles),

--- a/src/app/store/reducers/app.reducer.spec.ts
+++ b/src/app/store/reducers/app.reducer.spec.ts
@@ -12,46 +12,6 @@ describe('AppReducer', () => {
       expect(state).toBe(initialState);
     });
 
-    it('setTitle action should return correct state', () => {
-      const { initialState } = fromApp;
-      let action;
-      let state;
-
-      action = new fromAppActions.SetPageTitle('invite-user');
-      state = fromApp.reducer(initialState, action);
-
-      expect(state.pageTitle).toEqual('Invite user - Manage organisation');
-
-      action = new fromAppActions.SetPageTitle('organisation');
-      state = fromApp.reducer(initialState, action);
-
-      expect(state.pageTitle).toEqual('Organisation details - Manage organisation');
-
-      action = new fromAppActions.SetPageTitle('profile');
-      state = fromApp.reducer(initialState, action);
-
-      expect(state.pageTitle).toEqual('Profile - Manage organisation');
-
-      action = new fromAppActions.SetPageTitle('users');
-      state = fromApp.reducer(initialState, action);
-
-      expect(state.pageTitle).toEqual('Users - Manage organisation');
-
-      action = new fromAppActions.SetPageTitle('dummy');
-      state = fromApp.reducer(initialState, action);
-
-      expect(state.pageTitle).toEqual('Manage organisation');
-    });
-
-    it('setTitleError action should return correct state', () => {
-      const { initialState } = fromApp;
-
-      const action = new fromAppActions.SetPageTitleErrors();
-      const state = fromApp.reducer(initialState, action);
-
-      expect(state.pageTitle).toEqual('Error: ');
-    });
-
     it('should set correct user roles', () => {
       const { initialState } = fromApp;
       const payload = [

--- a/src/app/store/reducers/app.reducer.ts
+++ b/src/app/store/reducers/app.reducer.ts
@@ -65,24 +65,6 @@ export function reducer(
           jurisdictions
         };
 
-    case fromAction.SET_PAGE_TITLE: {
-      const pageTitle = AppUtils.setPageTitle(action.payload);
-      return {
-        ...state,
-        pageTitle
-      };
-    }
-
-    case fromAction.SET_PAGE_TITLE_ERRORS: {
-      const EXISTS = -1;
-      const pageTitle = (state.pageTitle.indexOf('Error') !== EXISTS) ?
-        state.pageTitle : `Error: ${state.pageTitle}`;
-      return {
-        ...state,
-        pageTitle
-      };
-    }
-
     case fromAction.SET_USER_ROLES: {
       const roles = [...action.payload];
       let navItems = [];
@@ -146,7 +128,6 @@ export function reducer(
   }
 }
 
-export const getPageTitle = (state: AppState) => state.pageTitle;
 export const getNavItems = (state: AppState) => state.navItems;
 export const getUserNavigation = (state: AppState) => state.userNav;
 export const getHeaderTitles = (state: AppState) => state.headerTitle;

--- a/src/app/store/selectors/app.selectors.spec.ts
+++ b/src/app/store/selectors/app.selectors.spec.ts
@@ -25,21 +25,6 @@ describe('App Selectors', () => {
     spyOn(store, 'dispatch').and.callThrough();
   });
 
-  describe('getPageTitle', () => {
-    it('should return page title', () => {
-      let result;
-
-      store.pipe(select(fromSelectors.getPageTitle))
-        .subscribe(value => (result = value));
-
-      expect(result).toEqual('');
-
-      store.dispatch(new fromActions.SetPageTitle('/organisation'));
-
-      expect(result).toEqual('Organisation details - Manage organisation');
-    });
-  });
-
   describe('getHeaderTitles', () => {
     it('should return heading titles', () => {
       let result;

--- a/src/app/store/selectors/app.selectors.ts
+++ b/src/app/store/selectors/app.selectors.ts
@@ -11,11 +11,6 @@ export const getAppState = createSelector(
   (state: fromAppFeature.AppState) => state
 );
 
-export const getPageTitle = createSelector(
-  getAppState,
-  fromAppFeature.getPageTitle
-);
-
 export const getHeaderTitles = createSelector(
   getAppState,
   fromAppFeature.getHeaderTitles

--- a/src/app/utils/app-utils.spec.ts
+++ b/src/app/utils/app-utils.spec.ts
@@ -89,55 +89,6 @@ describe('AppUtils', () => {
     expect(array).toEqual(state.userNav);
   });
 
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('invite-users');
-    expect(array).toEqual('Invite user - Manage organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('organisation-name');
-    expect(array).toEqual('Organisation name - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('organisation-address');
-    expect(array).toEqual('Organisation address - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('organisation-pba');
-    expect(array).toEqual('PBA - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('have-dx');
-    expect(array).toEqual('DX - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('organisation-dx');
-    expect(array).toEqual('DX reference - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('haveSra');
-    expect(array).toEqual('SRA - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('sraNumber');
-    expect(array).toEqual('SRA number - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('name');
-    expect(array).toEqual('Name - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('email-address');
-    expect(array).toEqual('Email - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('check');
-    expect(array).toEqual('Check answers - Register organisation');
-  });
-  it('should set correct page titles', () => {
-    const array = AppUtils.setPageTitle('register-org/register');
-    expect(array).toEqual('Register - Register organisation');
-  });
-
   it('should switch title', () => {
     const routerObj = {
       state: {

--- a/src/app/utils/app-utils.ts
+++ b/src/app/utils/app-utils.ts
@@ -81,61 +81,6 @@ export class AppUtils {
     return is24Hour ? formatDate(date, 'HH:mm', 'en-UK') : formatDate(date, 'h:mm a', 'en-UK').toLowerCase();
   }
 
-  public static setPageTitle(url): string {
-    /**
-     * it sets correct page titles based on the url.
-     */
-    if (url.indexOf('invite-user') !== -1) {
-      return 'Invite user - Manage organisation';
-    }
-    if (url.indexOf('profile') !== -1) {
-      return 'Profile - Manage organisation';
-    }
-    if (url.indexOf('users') !== -1) {
-      return 'Users - Manage organisation';
-    }
-    if (url.indexOf('organisation-name') !== -1) {
-      return 'Organisation name - Register organisation';
-    }
-    if (url.indexOf('organisation-address') !== -1) {
-      return 'Organisation address - Register organisation';
-    }
-    if (url.indexOf('organisation-pba') !== -1) {
-      return 'PBA - Register organisation';
-    }
-    if (url.indexOf('have-dx') !== -1) {
-      return 'DX - Register organisation';
-    }
-    if (url.indexOf('organisation-dx') !== -1) {
-      return 'DX reference - Register organisation';
-    }
-    if (url.indexOf('haveSra') !== -1) {
-      return 'SRA - Register organisation';
-    }
-    if (url.indexOf('sraNumber') !== -1) {
-      return 'SRA number - Register organisation';
-    }
-    if (url.indexOf('name') !== -1) {
-      return 'Name - Register organisation';
-    }
-    if (url.indexOf('email-address') !== -1) {
-      return 'Email - Register organisation';
-    }
-    if (url.indexOf('check') !== -1) {
-      return 'Check answers - Register organisation';
-    }
-    if (url.indexOf('organisation') !== -1) {
-      return 'Organisation details - Manage organisation';
-    }
-    if (url.indexOf('register-org/register') !== -1) {
-      return 'Register - Register organisation';
-    }
-    if (url.indexOf('register-org/confirmation') !== -1) {
-      return 'Confirmation - Register organisation';
-    }
-    return 'Manage organisation';
-  }
-
   // 04-Sep-2019 - Author U Denduluri
   // Function which returns the environment name based on the Url
   // by looking at the pattern

--- a/src/organisation/organisation.routing.ts
+++ b/src/organisation/organisation.routing.ts
@@ -4,7 +4,6 @@ import { ModuleWithProviders } from '@angular/core';
 import { OrganisationComponent } from './containers';
 import { OrganisationGuard } from 'src/organisation/guards/organisation.guard';
 import { HealthCheckGuard } from 'src/shared/guards/health-check.guard';
-import {TermsConditionGuard} from '../app/guards/termsCondition.guard';
 
 export const ROUTES: Routes = [
   {

--- a/src/register/register.routing.ts
+++ b/src/register/register.routing.ts
@@ -8,15 +8,24 @@ export const ROUTES: Routes = [
   {
     path: 'register',
     component: RegisterComponent,
+    data: {
+      title: 'Register - Register organisation'
+    }
   },
   {
     path: 'register/:pageId',
     component: RegisterComponent,
+    data: {
+      title: 'Register - Register organisation'
+    }
     // canActivate: [HealthCheckGuard] // TODO decide do we need this
   },
   {
     path: 'confirmation',
     component: SubmittedConfirmationComponent,
+    data: {
+      title: 'Confirmation - Register organisation'
+    }
     // canActivate: [HealthCheckGuard]
   }
 ];

--- a/src/style-guide/style-guide.routing.ts
+++ b/src/style-guide/style-guide.routing.ts
@@ -8,6 +8,9 @@ export const ROUTES: Routes = [
     {
       path: '',
       component: StyleGuideComponent,
+      data: {
+        title: 'Style guide'
+      }
       // canActivate: [AuthGuard],
     }
 ];

--- a/src/unassigned-cases/unassigned-cases.routing.ts
+++ b/src/unassigned-cases/unassigned-cases.routing.ts
@@ -13,7 +13,10 @@ export const ROUTES: Routes = [
             AuthGuard,
             FeatureToggleAccountGuard,
             RoleGuard
-        ]
+        ],
+        data: {
+          title: 'Unassigned cases'
+        }
     },
     {
       path: 'case-share',
@@ -22,7 +25,10 @@ export const ROUTES: Routes = [
         AuthGuard,
         FeatureToggleAccountGuard,
         RoleGuard
-      ]
+      ],
+      data: {
+        title: 'Share a case'
+      }
     },
     {
       path: 'case-share-confirm',
@@ -31,7 +37,10 @@ export const ROUTES: Routes = [
         AuthGuard,
         FeatureToggleAccountGuard,
         RoleGuard
-      ]
+      ],
+      data: {
+        title: 'Share a case'
+      }
     },
     {
       path: 'case-share-complete',
@@ -40,7 +49,10 @@ export const ROUTES: Routes = [
         AuthGuard,
         FeatureToggleAccountGuard,
         RoleGuard
-      ]
+      ],
+      data: {
+        title: 'Share a case'
+      }
     }
 ];
 

--- a/src/user-profile/userProfile.routing.ts
+++ b/src/user-profile/userProfile.routing.ts
@@ -16,6 +16,9 @@ export const ROUTES: Routes = [
     // canActivate: [false]
     redirectTo: 'organisation',
     pathMatch: 'full',
+    data: {
+      title: 'Profile'
+    }
   }
 ];
 

--- a/src/users/users.routing.ts
+++ b/src/users/users.routing.ts
@@ -13,29 +13,47 @@ export const ROUTES: Routes = [
       path: '',
       component: UsersComponent,
       canActivate: [HealthCheckGuard],
+      data: {
+        title: 'Users'
+      }
     },
     {
       path: 'user/:userId',
-      component: UserDetailsComponent
+      component: UserDetailsComponent,
+      data: {
+        title: 'User details'
+      }
     },
     {
       path: 'invite-user',
       component: InviteUserComponent,
       canActivate: [HealthCheckGuard],
+      data: {
+        title: 'Invite user'
+      }
     },
     {
       path: 'invite-user-success',
       component: InviteUserSuccessComponent,
       canActivate: [InviteUserSuccessGuard],
+      data: {
+        title: 'You\'ve invited'
+      }
     },
     {
       path: 'user/:userId/editpermission-failure',
       component: EditUserPermissionsFailureComponent,
+      data: {
+        title: 'Sorry, there is a problem with the service'
+      }
     },
     {
       path: 'user/:userId/editpermission',
       component: EditUserPermissionComponent,
-      canActivate: [FeatureToggleEditUserGuard]
+      canActivate: [FeatureToggleEditUserGuard],
+      data: {
+        title: 'Edit user'
+      }
     }
 ];
 

--- a/test/e2e/features/pageObjects/createOrganisationObjects.js
+++ b/test/e2e/features/pageObjects/createOrganisationObjects.js
@@ -12,7 +12,7 @@ class CreateOrganisationObjects {
     this.signinBtn = element(by.css("input.button"));
     this.signOutlink = element(by.xpath("//a[contains(text(),'Signout')]"));
     this.failure_error_heading = element(by.css("[id='validation-error-summary-heading']"));
-    this.start_button = element(by.xpath("//*[@id='content']/div/div/a"));
+    this.start_button = element(by.xpath('//a[contains(text(),"Start")]'));
     this.org_name = element(by.css("[id='orgName']"));
     this.continue_button = element(by.css("[id='createButtonContinue']"));
     this.officeAddressOne =element(by.xpath("//*[@id=\"officeAddressOne\"]"));

--- a/test/e2e/features/pageObjects/createOrganisationObjects.js
+++ b/test/e2e/features/pageObjects/createOrganisationObjects.js
@@ -12,7 +12,7 @@ class CreateOrganisationObjects {
     this.signinBtn = element(by.css("input.button"));
     this.signOutlink = element(by.xpath("//a[contains(text(),'Signout')]"));
     this.failure_error_heading = element(by.css("[id='validation-error-summary-heading']"));
-    this.start_button = element(by.xpath('//a[contains(text(),"Start")]'));
+    this.start_button = element(by.xpath("//*[@id='content']/div/div/a"));
     this.org_name = element(by.css("[id='orgName']"));
     this.continue_button = element(by.css("[id='createButtonContinue']"));
     this.officeAddressOne =element(by.xpath("//*[@id=\"officeAddressOne\"]"));


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-4752


### Change description ###
Move Page Title functionality out of the ngrx Store and use the built in Angular Title service and routing. Update page titles to correspond with the page and include the GOV.UK suffix. Remove redundant tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
