### PR TITLE
EUI-6548: Construct Elasticsearch API request body dynamically

### DIFF
--- a/api/caaCases/caaCases.util.spec.ts
+++ b/api/caaCases/caaCases.util.spec.ts
@@ -1,10 +1,185 @@
 import { expect } from 'chai';
 import { caseAssignment } from './caaCases.constants';
-import { getApiPath } from './caaCases.util';
+import { getApiPath, getRequestBody } from './caaCases.util';
+import { CaaCasesPageType } from './enums';
 
 describe('util', () => {
   it('getApiPath', () => {
     const fullPath = getApiPath('http://somePath', 'caseTypeId1');
     expect(fullPath).to.equal(`http://somePath${caseAssignment}?ctid=caseTypeId1&use_case=ORGCASES`);
-  })
-})
+  });
+
+  it('should generate the request body for retrieving all assigned cases', () => {
+    const requestBody = getRequestBody('GCXGCY1', 0, 10, CaaCasesPageType.AssignedCases);
+    // Use the "eql" assertion because the test is *not* for strict equality (which is what "equal" asserts)
+    expect(requestBody).to.eql({
+      from: 0,
+      query: {
+        bool: {
+          filter: [
+            {
+              multi_match: {
+                fields: [ 'data.*.Organisation.OrganisationID' ],
+                query: 'GCXGCY1',
+                type: 'phrase'
+              }
+            },
+            {
+              bool: {
+                must: [
+                  {
+                    range: {
+                      'supplementary_data.orgs_assigned_users.GCXGCY1': {
+                        gt: 0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      size: 10,
+      sort: [
+        {
+          created_date: 'desc'
+        }
+      ]
+    });
+  });
+
+  it('should generate the request body for retrieving all unassigned cases', () => {
+    const requestBody = getRequestBody('GCXGCY1', 0, 10, CaaCasesPageType.UnassignedCases);
+    // Use the "eql" assertion because the test is *not* for strict equality (which is what "equal" asserts)
+    expect(requestBody).to.eql({
+      from: 0,
+      query: {
+        bool: {
+          filter: [
+            {
+              multi_match: {
+                fields: [ 'data.*.Organisation.OrganisationID' ],
+                query: 'GCXGCY1',
+                type: 'phrase'
+              }
+            },
+            {
+              bool: {
+                must_not: [
+                  {
+                    range: {
+                      'supplementary_data.orgs_assigned_users.GCXGCY1': {
+                        gt: 0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      size: 10,
+      sort: [
+        {
+          created_date: 'desc'
+        }
+      ]
+    });
+  });
+
+  it('should generate the request body for retrieving a specific assigned case', () => {
+    const requestBody = getRequestBody('GCXGCY1', 0, 10, CaaCasesPageType.AssignedCases, '1111222233334444');
+    // Use the "eql" assertion because the test is *not* for strict equality (which is what "equal" asserts)
+    expect(requestBody).to.eql({
+      from: 0,
+      query: {
+        bool: {
+          must: [
+            {
+              match: {
+                'reference.keyword': '1111222233334444'
+              }
+            }
+          ],
+          filter: [
+            {
+              multi_match: {
+                fields: [ 'data.*.Organisation.OrganisationID' ],
+                query: 'GCXGCY1',
+                type: 'phrase'
+              }
+            },
+            {
+              bool: {
+                must: [
+                  {
+                    range: {
+                      'supplementary_data.orgs_assigned_users.GCXGCY1': {
+                        gt: 0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      size: 10,
+      sort: [
+        {
+          created_date: 'desc'
+        }
+      ]
+    });
+  });
+
+  it('should generate the request body for retrieving a specific unassigned case', () => {
+    const requestBody = getRequestBody('GCXGCY1', 0, 10, CaaCasesPageType.UnassignedCases, '1111222233334444');
+    // Use the "eql" assertion because the test is *not* for strict equality (which is what "equal" asserts)
+    expect(requestBody).to.eql({
+      from: 0,
+      query: {
+        bool: {
+          must: [
+            {
+              match: {
+                'reference.keyword': '1111222233334444'
+              }
+            }
+          ],
+          filter: [
+            {
+              multi_match: {
+                fields: [ 'data.*.Organisation.OrganisationID' ],
+                query: 'GCXGCY1',
+                type: 'phrase'
+              }
+            },
+            {
+              bool: {
+                must_not: [
+                  {
+                    range: {
+                      'supplementary_data.orgs_assigned_users.GCXGCY1': {
+                        gt: 0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      size: 10,
+      sort: [
+        {
+          created_date: 'desc'
+        }
+      ]
+    });
+  });
+});

--- a/api/caaCases/caaCases.util.ts
+++ b/api/caaCases/caaCases.util.ts
@@ -1,6 +1,6 @@
-import { CaseHeader, CcdCase, CcdCaseData, CcdColumnConfig, CaaCases } from './interfaces'
-import { caseAssignment, caseId, caseTypeStr } from './caaCases.constants'
-import { CaaCasesFilterType } from './enums';
+import { caseAssignment, caseId, caseTypeStr } from './caaCases.constants';
+import { CaaCasesPageType } from './enums';
+import { CaaCases, CaseHeader, CcdCase, CcdCaseData, CcdColumnConfig } from './interfaces';
 
 export function getApiPath(ccdPath: string, caseTypeId: string) {
   return `${ccdPath}${caseAssignment}?ctid=${caseTypeId}&use_case=ORGCASES`;
@@ -17,181 +17,19 @@ export function mapCcdCases(caseType: string, ccdCase: CcdCase): CaaCases {
   };
 }
 
-export function getRequestBodyForAssignedCases(organisationID: string, pageNo: number, pageSize: number, caaCasesFilterType: string, caaCasesFilterValue: string) {
+export function getRequestBody(organisationID: string, pageNo: number, pageSize: number, caaCasesPageType: string, caaCasesFilterValue?: string) {
   const organisationAssignedUsersKey = `supplementary_data.orgs_assigned_users.${organisationID}`;
   const reference = 'reference.keyword';
-
-  switch(caaCasesFilterType) {
-    case CaaCasesFilterType.AllAssignees:
-      return {
-        from: pageNo,
-        query: {
-          bool: {
-            filter: [
-              {
-                multi_match: {
-                  fields: ['data.*.Organisation.OrganisationID'],
-                  query: `${organisationID}`,
-                  type: 'phrase',
-                },
-              },
-              {
-                bool: {
-                  must: [
-                    { range: { [organisationAssignedUsersKey]: { gt: 0}}},
-                  ],
-                },
-              },
-            ],
-          },
-        },
-        size: pageSize,
-        sort: [
-          {
-            created_date: 'desc'
-          },
-        ]
-      }
-    case CaaCasesFilterType.AssigneeName:
-      // TODO: To be implemented/modified
-      return {
-        from: pageNo,
-        query: {
-          bool: {
-            filter: [
-              {
-                multi_match: {
-                  fields: ['data.*.Organisation.OrganisationID'],
-                  query: `${organisationID}`,
-                  type: 'phrase',
-                },
-              },
-              {
-                bool: {
-                  must: [
-                    { range: { [organisationAssignedUsersKey]: { gt: 0}}},
-                  ],
-                },
-              },
-            ],
-          },
-        },
-        size: pageSize,
-        sort: [
-          {
-            created_date: 'desc'
-          },
-        ]
-      }
-    case CaaCasesFilterType.CaseReferenceNumber:
-      return {
-        from: pageNo,
-        query: {
-          bool: {
-            must: [
-              { match: { [reference]: caaCasesFilterValue }},
-            ],
-            filter: [
-              {
-                multi_match: {
-                  fields: ['data.*.Organisation.OrganisationID'],
-                  query: `${organisationID}`,
-                  type: 'phrase',
-                },
-              },
-              {
-                bool: {
-                  must: [
-                    { range: { [organisationAssignedUsersKey]: { gt: 0}}},
-                  ],
-                },
-              },
-            ],
-          },
-        },
-        size: pageSize,
-        sort: [
-          {
-            created_date: 'desc'
-          },
-        ]
-      }
-    default:
-      return {
-        from: pageNo,
-        query: {
-          bool: {
-            filter: [
-              {
-                multi_match: {
-                  fields: ['data.*.Organisation.OrganisationID'],
-                  query: `${organisationID}`,
-                  type: 'phrase',
-                },
-              },
-              {
-                bool: {
-                  must: [
-                    { range: { [organisationAssignedUsersKey]: { gt: 0}}},
-                  ],
-                },
-              },
-            ],
-          },
-        },
-        size: pageSize,
-        sort: [
-          {
-            created_date: 'desc'
-          },
-        ]
-      }
-  }
-}
-
-export function getRequestBodyForUnassignedCases(organisationID: string, pageNo: number, pageSize: number, caaCasesFilterType: string, caaCasesFilterValue: string) {
-  const organisationAssignedUsersKey = `supplementary_data.orgs_assigned_users.${organisationID}`
-  const reference = 'reference.keyword';
-
-  if (caaCasesFilterType === CaaCasesFilterType.CaseReferenceNumber) {
-    return {
-      from: pageNo,
-      query: {
-        bool: {
-          must: [
-            { match: { [reference]: caaCasesFilterValue }},
-          ],
-          filter: [
-            {
-              multi_match: {
-                fields: ['data.*.Organisation.OrganisationID'],
-                query: `${organisationID}`,
-                type: 'phrase',
-              },
-            },
-            {
-              bool: {
-                must_not: [
-                  { range: { [organisationAssignedUsersKey]: { gt: 0}}},
-                ],
-              },
-            },
-          ],
-        },
-      },
-      size: pageSize,
-      sort: [
-        {
-          created_date: 'desc'
-        },
-      ]
-    };
-  }
 
   return {
     from: pageNo,
     query: {
       bool: {
+        ...(caaCasesFilterValue && {
+          must: [
+            { match: { [reference]: caaCasesFilterValue } },
+          ],
+        }),
         filter: [
           {
             multi_match: {
@@ -202,9 +40,16 @@ export function getRequestBodyForUnassignedCases(organisationID: string, pageNo:
           },
           {
             bool: {
-              must_not: [
-                { range: { [organisationAssignedUsersKey]: { gt: 0}}},
-              ],
+              ...(caaCasesPageType === CaaCasesPageType.AssignedCases && {
+                must: [
+                  { range: { [organisationAssignedUsersKey]: { gt: 0 } } },
+                ],
+              }),
+              ...(caaCasesPageType === CaaCasesPageType.UnassignedCases && {
+                must_not: [
+                  { range: { [organisationAssignedUsersKey]: { gt: 0 } } },
+                ],
+              }),
             },
           },
         ],

--- a/api/caaCases/index.ts
+++ b/api/caaCases/index.ts
@@ -1,21 +1,17 @@
-import { NextFunction, Request, Response, Router } from 'express'
-import { getConfigValue } from '../configuration'
-import { SERVICES_MCA_PROXY_API_PATH } from '../configuration/references'
-import { getApiPath, getRequestBodyForAssignedCases, getRequestBodyForUnassignedCases, mapCcdCases } from './caaCases.util'
-import { CaaCasesPageType } from './enums';
+import { NextFunction, Request, Response, Router } from 'express';
+import { getConfigValue } from '../configuration';
+import { SERVICES_MCA_PROXY_API_PATH } from '../configuration/references';
+import { getApiPath, getRequestBody, mapCcdCases } from './caaCases.util';
 
 export async function handleCaaCases(req: Request, res: Response, next: NextFunction) {
   const caseTypeId = req.query.caseTypeId as string;
   const caaCasesPageType = req.query.caaCasesPageType as string;
-  const caaCasesFilterType = req.query.caaCasesFilterType as string;
   const caaCasesFilterValue = req.query.caaCasesFilterValue as string;
   const path = getApiPath(getConfigValue(SERVICES_MCA_PROXY_API_PATH), caseTypeId);
   const page: number = (+req.query.pageNo || 1) - 1;
   const size: number = (+req.query.pageSize);
   const fromNo: number = page * size;
-  const payload = caaCasesPageType === CaaCasesPageType.UnassignedCases
-    ? getRequestBodyForUnassignedCases(req.session.auth.orgId, fromNo, size, caaCasesFilterType, caaCasesFilterValue)
-    : getRequestBodyForAssignedCases(req.session.auth.orgId, fromNo, size, caaCasesFilterType, caaCasesFilterValue);
+  const payload = getRequestBody(req.session.auth.orgId, fromNo, size, caaCasesPageType, caaCasesFilterValue);
 
   try {
     const response = await req.http.post(path, payload);

--- a/src/caa-cases/containers/caa-cases/caa-cases.component.ts
+++ b/src/caa-cases/containers/caa-cases/caa-cases.component.ts
@@ -136,10 +136,10 @@ export class CaaCasesComponent implements OnInit {
 
   public loadDataFromStore(): void {
     if (this.caaCasesPageType === CaaCasesPageType.UnassignedCases) {
-      this.store.dispatch(new fromStore.LoadUnassignedCases({caseType: this.currentCaseType, pageNo: this.currentPageNo, pageSize: this.paginationPageSize, caaCasesFilterType: this.selectedFilterType, caaCasesFilterValue: this.selectedFilterValue}));
+      this.store.dispatch(new fromStore.LoadUnassignedCases({caseType: this.currentCaseType, pageNo: this.currentPageNo, pageSize: this.paginationPageSize, caaCasesFilterValue: this.selectedFilterValue}));
       this.cases$ = this.store.pipe(select(fromStore.getAllUnassignedCaseData));
     } else {
-      this.store.dispatch(new fromStore.LoadAssignedCases({caseType: this.currentCaseType, pageNo: this.currentPageNo, pageSize: this.paginationPageSize, caaCasesFilterType: this.selectedFilterType, caaCasesFilterValue: this.selectedFilterValue}));
+      this.store.dispatch(new fromStore.LoadAssignedCases({caseType: this.currentCaseType, pageNo: this.currentPageNo, pageSize: this.paginationPageSize, caaCasesFilterValue: this.selectedFilterValue}));
       this.cases$ = this.store.pipe(select(fromStore.getAllAssignedCaseData));
     }
   }

--- a/src/caa-cases/services/caa-cases.service.spec.ts
+++ b/src/caa-cases/services/caa-cases.service.spec.ts
@@ -1,4 +1,3 @@
-import { CaaCasesFilterType } from 'api/caaCases/enums';
 import { of } from 'rxjs';
 import { CaaCasesPageType } from '../models/caa-cases.enum';
 import { CaaCasesService } from './caa-cases.service';
@@ -8,16 +7,32 @@ describe('CaaCasesService', () => {
     const mockHttp = jasmine.createSpyObj('http', ['post']);
     mockHttp.post.and.returnValue(of({}));
     const service = new CaaCasesService(mockHttp);
-    service.getCaaCases('caseTypeId1', 1, 10, CaaCasesFilterType.None, null, CaaCasesPageType.AssignedCases);
-    expect(mockHttp.post).toHaveBeenCalledWith(`${CaaCasesService.caaCasesUrl}?caseTypeId=caseTypeId1&pageNo=1&pageSize=10&caaCasesPageType=assigned-cases&caaCasesFilterType=none&caaCasesFilterValue=null`, null);
+    service.getCaaCases('caseTypeId1', 1, 10, CaaCasesPageType.AssignedCases, null);
+    expect(mockHttp.post).toHaveBeenCalledWith(`${CaaCasesService.caaCasesUrl}?caseTypeId=caseTypeId1&pageNo=1&pageSize=10&caaCasesPageType=assigned-cases`, null);
+  });
+
+  it('getCaaAssignedCases with filter value', () => {
+    const mockHttp = jasmine.createSpyObj('http', ['post']);
+    mockHttp.post.and.returnValue(of({}));
+    const service = new CaaCasesService(mockHttp);
+    service.getCaaCases('caseTypeId1', 1, 10, CaaCasesPageType.AssignedCases, '1111222233334444');
+    expect(mockHttp.post).toHaveBeenCalledWith(`${CaaCasesService.caaCasesUrl}?caseTypeId=caseTypeId1&pageNo=1&pageSize=10&caaCasesPageType=assigned-cases&caaCasesFilterValue=1111222233334444`, null);
   });
 
   it('getCaaUnassignedCases', () => {
     const mockHttp = jasmine.createSpyObj('http', ['post']);
     mockHttp.post.and.returnValue(of({}));
     const service = new CaaCasesService(mockHttp);
-    service.getCaaCases('caseTypeId1', 1, 10, CaaCasesFilterType.None, null, CaaCasesPageType.UnassignedCases);
-    expect(mockHttp.post).toHaveBeenCalledWith(`${CaaCasesService.caaCasesUrl}?caseTypeId=caseTypeId1&pageNo=1&pageSize=10&caaCasesPageType=unassigned-cases&caaCasesFilterType=none&caaCasesFilterValue=null`, null);
+    service.getCaaCases('caseTypeId1', 1, 10, CaaCasesPageType.UnassignedCases, null);
+    expect(mockHttp.post).toHaveBeenCalledWith(`${CaaCasesService.caaCasesUrl}?caseTypeId=caseTypeId1&pageNo=1&pageSize=10&caaCasesPageType=unassigned-cases`, null);
+  });
+
+  it('getCaaUnassignedCases with filter value', () => {
+    const mockHttp = jasmine.createSpyObj('http', ['post']);
+    mockHttp.post.and.returnValue(of({}));
+    const service = new CaaCasesService(mockHttp);
+    service.getCaaCases('caseTypeId1', 1, 10, CaaCasesPageType.UnassignedCases, '1111222233334444');
+    expect(mockHttp.post).toHaveBeenCalledWith(`${CaaCasesService.caaCasesUrl}?caseTypeId=caseTypeId1&pageNo=1&pageSize=10&caaCasesPageType=unassigned-cases&caaCasesFilterValue=1111222233334444`, null);
   });
 
   it('getCaaCaseTypes', () => {

--- a/src/caa-cases/services/caa-cases.service.ts
+++ b/src/caa-cases/services/caa-cases.service.ts
@@ -12,8 +12,11 @@ export class CaaCasesService {
   }
 
   public getCaaCases(
-    caseTypeId: string, pageNo: number, pageSize: number, caaCasesFilterType: string, caaCasesFilterValue: string, caaCasesPageType: string): Observable<any> {
-    const url = `${CaaCasesService.caaCasesUrl}?caseTypeId=${caseTypeId}&pageNo=${pageNo}&pageSize=${pageSize}&caaCasesPageType=${caaCasesPageType}&caaCasesFilterType=${caaCasesFilterType}&caaCasesFilterValue=${caaCasesFilterValue}`;
+    caseTypeId: string, pageNo: number, pageSize: number, caaCasesPageType: string, caaCasesFilterValue: string | null): Observable<any> {
+    let url = `${CaaCasesService.caaCasesUrl}?caseTypeId=${caseTypeId}&pageNo=${pageNo}&pageSize=${pageSize}&caaCasesPageType=${caaCasesPageType}`;
+    if (caaCasesFilterValue) {
+      url += `&caaCasesFilterValue=${caaCasesFilterValue}`;
+    }
     return this.http.post<any>(url, null);
   }
 

--- a/src/caa-cases/store/actions/caa-cases.actions.spec.ts
+++ b/src/caa-cases/store/actions/caa-cases.actions.spec.ts
@@ -1,5 +1,4 @@
 import { CaaCases } from 'api/caaCases/interfaces';
-import { CaaCasesFilterType } from '../../models/caa-cases.enum';
 import * as fromActions from './caa-cases.actions';
 
 describe('Caa actions', () => {
@@ -7,9 +6,8 @@ describe('Caa actions', () => {
     const caseType = 'caseTypeId1';
     const pageNo = 1;
     const pageSize = 10;
-    const caaCasesFilterType = CaaCasesFilterType.None;
     const caaCasesFilterValue = null;
-    const payload = { caseType, pageNo, pageSize, caaCasesFilterType, caaCasesFilterValue };
+    const payload = { caseType, pageNo, pageSize, caaCasesFilterValue };
     const action = new fromActions.LoadAssignedCases(payload);
     expect({ ...action }).toEqual({
       payload,
@@ -39,9 +37,8 @@ describe('Caa actions', () => {
     const caseType = 'caseTypeId1';
     const pageNo = 1;
     const pageSize = 10;
-    const caaCasesFilterType = CaaCasesFilterType.None;
     const caaCasesFilterValue = null;
-    const payload = { caseType, pageNo, pageSize, caaCasesFilterType, caaCasesFilterValue };
+    const payload = { caseType, pageNo, pageSize, caaCasesFilterValue };
     const action = new fromActions.LoadUnassignedCases(payload);
     expect({ ...action }).toEqual({
       payload,

--- a/src/caa-cases/store/actions/caa-cases.actions.ts
+++ b/src/caa-cases/store/actions/caa-cases.actions.ts
@@ -14,7 +14,7 @@ export const UPDATE_SELECTION_FOR_CASE_TYPE = '[CAA CASES] Update Selection For 
 
 export class LoadAssignedCases implements Action {
   public readonly type = LOAD_ASSIGNED_CASES;
-  constructor(public payload: {caseType: string, pageNo: number, pageSize: number, caaCasesFilterType: string, caaCasesFilterValue: string}) {}
+  constructor(public payload: {caseType: string, pageNo: number, pageSize: number, caaCasesFilterValue: string | null}) {}
 }
 
 export class LoadAssignedCasesSuccess implements Action {
@@ -29,7 +29,7 @@ export class LoadAssignedCasesFailure implements Action {
 
 export class LoadUnassignedCases implements Action {
     public readonly type = LOAD_UNASSIGNED_CASES;
-    constructor(public payload: {caseType: string, pageNo: number, pageSize: number, caaCasesFilterType: string, caaCasesFilterValue: string}) {}
+    constructor(public payload: {caseType: string, pageNo: number, pageSize: number, caaCasesFilterValue: string | null}) {}
 }
 
 export class LoadUnassignedCasesSuccess implements Action {

--- a/src/caa-cases/store/effects/caa-cases.effects.spec.ts
+++ b/src/caa-cases/store/effects/caa-cases.effects.spec.ts
@@ -9,7 +9,6 @@ import { LoggerService } from '../../../shared/services/logger.service';
 import { CaaCases } from '../../models/caa-cases.model';
 import * as caaCasesActions from '../actions/caa-cases.actions';
 import { CaaCasesEffects } from './caa-cases.effects';
-import { CaaCasesFilterType } from 'src/caa-cases/models/caa-cases.enum';
 
 describe('CaaCasesEffects', () => {
   let actions$;
@@ -39,9 +38,8 @@ describe('CaaCasesEffects', () => {
       const caseType = '';
       const pageNo = 1;
       const pageSize = 10;
-      const caaCasesFilterType = CaaCasesFilterType.None;
       const caaCasesFilterValue = null;
-      const payload = { caseType, pageNo, pageSize, caaCasesFilterType, caaCasesFilterValue };
+      const payload = { caseType, pageNo, pageSize, caaCasesFilterValue };
       const action = new caaCasesActions.LoadAssignedCases(payload);
       const completion = new caaCasesActions.LoadAssignedCasesSuccess(assignedCases);
       actions$ = hot('-a', { a: action });
@@ -65,9 +63,8 @@ describe('CaaCasesEffects', () => {
       const caseType = '';
       const pageNo = 1;
       const pageSize = 10;
-      const caaCasesFilterType = CaaCasesFilterType.None;
       const caaCasesFilterValue = null;
-      const payload = { caseType, pageNo, pageSize, caaCasesFilterType, caaCasesFilterValue };
+      const payload = { caseType, pageNo, pageSize, caaCasesFilterValue };
       const action = new caaCasesActions.LoadAssignedCases(payload);
       const completion = new caaCasesActions.LoadAssignedCasesFailure(error);
       actions$ = hot('-a', { a: action });
@@ -82,9 +79,8 @@ describe('CaaCasesEffects', () => {
       const caseType = '';
       const pageNo = 1;
       const pageSize = 10;
-      const caaCasesFilterType = CaaCasesFilterType.None;
       const caaCasesFilterValue = null;
-      const payload = { caseType, pageNo, pageSize, caaCasesFilterType, caaCasesFilterValue };
+      const payload = { caseType, pageNo, pageSize, caaCasesFilterValue };
       const action = new caaCasesActions.LoadUnassignedCases(payload);
       const completion = new caaCasesActions.LoadUnassignedCasesSuccess(unassignedCases);
       actions$ = hot('-a', { a: action });
@@ -108,9 +104,8 @@ describe('CaaCasesEffects', () => {
       const caseType = '';
       const pageNo = 1;
       const pageSize = 10;
-      const caaCasesFilterType = CaaCasesFilterType.None;
       const caaCasesFilterValue = null;
-      const payload = { caseType, pageNo, pageSize, caaCasesFilterType, caaCasesFilterValue };
+      const payload = { caseType, pageNo, pageSize, caaCasesFilterValue };
       const action = new caaCasesActions.LoadUnassignedCases(payload);
       const completion = new caaCasesActions.LoadUnassignedCasesFailure(error);
       actions$ = hot('-a', { a: action });

--- a/src/caa-cases/store/effects/caa-cases.effects.ts
+++ b/src/caa-cases/store/effects/caa-cases.effects.ts
@@ -22,7 +22,7 @@ export class CaaCasesEffects {
   public loadAssignedCases$ = this.actions$.pipe(
     ofType(fromCaaActions.LOAD_ASSIGNED_CASES),
     switchMap((action: fromCaaActions.LoadAssignedCases) => {
-      return this.caaCasesService.getCaaCases(action.payload.caseType, action.payload.pageNo, action.payload.pageSize, action.payload.caaCasesFilterType, action.payload.caaCasesFilterValue, CaaCasesPageType.AssignedCases).pipe(
+      return this.caaCasesService.getCaaCases(action.payload.caseType, action.payload.pageNo, action.payload.pageSize, CaaCasesPageType.AssignedCases, action.payload.caaCasesFilterValue).pipe(
         map(caaCases => new fromCaaActions.LoadAssignedCasesSuccess(caaCases)),
         catchError(error => CaaCasesEffects.handleError(error, this.loggerService, CaaCasesPageType.AssignedCases))
       );
@@ -33,7 +33,7 @@ export class CaaCasesEffects {
   public loadUnassignedCases$ = this.actions$.pipe(
     ofType(fromCaaActions.LOAD_UNASSIGNED_CASES),
     switchMap((action: fromCaaActions.LoadUnassignedCases) => {
-      return this.caaCasesService.getCaaCases(action.payload.caseType, action.payload.pageNo, action.payload.pageSize, action.payload.caaCasesFilterType, action.payload.caaCasesFilterValue, CaaCasesPageType.UnassignedCases).pipe(
+      return this.caaCasesService.getCaaCases(action.payload.caseType, action.payload.pageNo, action.payload.pageSize, CaaCasesPageType.UnassignedCases, action.payload.caaCasesFilterValue).pipe(
         map(caaCases => new fromCaaActions.LoadUnassignedCasesSuccess(caaCases)),
         catchError(error => CaaCasesEffects.handleError(error, this.loggerService, CaaCasesPageType.UnassignedCases))
       );
@@ -43,7 +43,7 @@ export class CaaCasesEffects {
   @Effect()
   public loadCaseTypes$ = this.actions$.pipe(
     ofType(fromCaaActions.LOAD_CASE_TYPES),
-    switchMap((action: fromCaaActions.LoadCaseTypes) => {
+    switchMap(() => {
       return this.caaCasesService.getCaaCaseTypes().pipe(
         map(caaCaseTypes => {
           const navItems = CaaCasesUtil.getCaaNavItems(caaCaseTypes);


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-6548](https://tools.hmcts.net/jira/browse/EUI-6548)

### Change description ###
Refactor multiple variants of the request body sent when querying the Elasticsearch API, to a single version that is constructed dynamically from the request query parameters passed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
