### PR TITLE
EUI-6251

### DIFF
--- a/projects/hmcts-form-builder/src/lib/components/validation-header/validation-header.component.html
+++ b/projects/hmcts-form-builder/src/lib/components/validation-header/validation-header.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert"
      data-module="error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
         There is a problem

--- a/src/fee-accounts/components/notifications/fee-account-error-notification.component.html
+++ b/src/fee-accounts/components/notifications/fee-account-error-notification.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="errorMessages.length > 0">
-  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
         There is a problem
       </h2>

--- a/src/register/components/notification-banner/notification-banner.component.html
+++ b/src/register/components/notification-banner/notification-banner.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert"
   data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
     There is a problem

--- a/src/register/containers/hmcts-form-builder/src/lib/components/validation-header/validation-header.component.html
+++ b/src/register/containers/hmcts-form-builder/src/lib/components/validation-header/validation-header.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert"
      data-module="error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
         There is a problem

--- a/src/shared/components/hmcts-error-summary/hmcts-error-summary.component.html
+++ b/src/shared/components/hmcts-error-summary/hmcts-error-summary.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!showWarningMessage" id="errorSummary" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+<div *ngIf="!showWarningMessage" id="errorSummary" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert"
                   data-module="error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
     {{header}}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-6251


### Change description ###
MO - 2.4.3 Focus Order - Keyboard focus jumps to footer/continue button, instead of the error summary links when tabbing after error message is announced


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
