### PR TITLE
Bug/e UI 8800

### DIFF
--- a/src/register-org/register-org.routing.ts
+++ b/src/register-org/register-org.routing.ts
@@ -20,11 +20,11 @@ import { RegisterOrgModule } from './register-org.module';
 export const ROUTES: Routes = [
   {
     path: '',
-    redirectTo: 'before-you-start',
+    redirectTo: 'register',
     pathMatch: 'full'
   },
   {
-    path: 'before-you-start',
+    path: 'register',
     component: BeforeYouStartComponent
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EUI-8800

### Change description ###

Register Org Old route was `/register-org/register`
Register Org New Route should be similar `/register-org-new/register`

This will fix the default route and also stop redirecting the user to Login Page
before-you-start route should be `register`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
