### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,7 +1,7 @@
 locals {
   app_full_name     = "xui-${var.component}"
   ase_name          = "core-compute-${var.env}"
-  local_env         = (var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env
+  local_env         = (var.env == "preview" || var.env == "spreview") ? (var.env == "preview") ? "aat" : "saat" : var.env
   shared_vault_name = "${var.shared_product_name}-${local.local_env}"
 }
 
@@ -36,21 +36,21 @@ module "redis6-cache" {
   public_network_access_enabled = false
 }
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${local.app_full_name}-appinsights-${var.env}"
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env                 = var.env
+  product             = var.product
+  name                = "${local.app_full_name}-appinsights"
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
-  application_type    = var.application_type
 
-  tags = var.common_tags
+  common_tags = var.common_tags
+}
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
 }
 
 resource "azurerm_resource_group" "rg" {

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -3,7 +3,7 @@ output "microserviceName" {
 }
 
 output "vaultName" {
-    value = local.shared_vault_name
+  value = local.shared_vault_name
 }
 
 output "vaultUri" {
@@ -11,6 +11,6 @@ output "vaultUri" {
 }
 
 output "appInsightsInstrumentationKey" {
-  value = azurerm_application_insights.appinsights.instrumentation_key
+  value     = module.application_insights.instrumentation_key
   sensitive = true
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.