### PR TITLE
GA-76 invite user button redirect to new manage user component

### DIFF
--- a/src/users/containers/manage-user/manage-user.component.html
+++ b/src/users/containers/manage-user/manage-user.component.html
@@ -19,4 +19,17 @@
       onSelectedCaseManagamentPermissionsChange($event)
     "
   ></app-organisation-access-permissions>
+
+  <div class="govuk-button-group">
+    <button
+      type="button"
+      data-prevent-double-click="true"
+      class="govuk-button"
+      data-module="govuk-button"
+      (click)="onSubmit()"
+    >
+      Submit
+    </button>
+    <a class="govuk-link" [routerLink]="backUrl">Cancel</a>
+  </div>
 </app-hmcts-main-wrapper>

--- a/src/users/containers/manage-user/manage-user.component.ts
+++ b/src/users/containers/manage-user/manage-user.component.ts
@@ -105,6 +105,22 @@ export class ManageUserComponent implements OnInit, OnDestroy {
     this.loggerService.debug('updatedUser', this.updatedUser);
   }
 
+  onSubmit() {
+    if (this.userId) {
+      this.updateUser();
+    } else {
+      this.inviteUser();
+    }
+  }
+
+  private inviteUser() {
+    // TODO: implement
+  }
+
+  private updateUser() {
+    // TODO: implement
+  }
+
   private getBackurl(userId: string): string {
     return !!userId ? `/users/user/${userId}` : '/users';
   }

--- a/src/users/containers/users/users.component.ts
+++ b/src/users/containers/users/users.component.ts
@@ -33,7 +33,7 @@ export class UsersComponent implements OnInit, OnDestroy {
   ) {}
 
   public ngOnInit(): void {
-    this.searchFiltersEnabled$ = this.featureToggleService.getValue('ogd-invite-user-flow', true);
+    this.searchFiltersEnabled$ = this.featureToggleService.getValue('ogd-invite-user-flow', false);
     this.loadUsers();
   }
 

--- a/src/users/store/effects/users.effects.ts
+++ b/src/users/store/effects/users.effects.ts
@@ -1,20 +1,22 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { catchError, concatMap, map, switchMap } from 'rxjs/operators';
+import { catchError, concatMap, map, switchMap, take } from 'rxjs/operators';
 import * as fromRoot from '../../../app/store';
 import { LoggerService } from '../../../shared/services/logger.service';
 import { UsersService } from '../../services';
 import * as usersActions from '../actions';
 import * as orgActions from '../../../organisation/store/actions';
 import { PrdUser } from 'src/users/models/prd-users.model';
+import { Store, select } from '@ngrx/store';
 
 @Injectable()
 export class UsersEffects {
   constructor(
     private readonly actions$: Actions,
     private readonly usersService: UsersService,
-    private readonly loggerService: LoggerService
+    private readonly loggerService: LoggerService,
+    private readonly appStore: Store<fromRoot.State>,
   ) {}
 
   public loadUsers$ = createEffect(() =>
@@ -165,14 +167,37 @@ export class UsersEffects {
   public inviteNewUser$ = createEffect(() =>
     this.actions$.pipe(
       ofType(usersActions.INVITE_NEW_USER),
-      map(() => new fromRoot.Go({ path: ['users/invite-user'] }))
+      switchMap(() => {
+        return this.appStore.pipe(
+          select(fromRoot.getOgdInviteUserFlowFeatureIsEnabled),
+          take(1),
+          map((isEnabled) => {
+            console.log('isEnabled', isEnabled);
+            if (isEnabled) {
+              return new fromRoot.Go({ path: ['users/manage'] });
+            }
+            return new fromRoot.Go({ path: ['users/invite-user'] });
+          })
+        );
+      })
     )
   );
 
   public reinviteUser$ = createEffect(() =>
     this.actions$.pipe(
       ofType(usersActions.REINVITE_PENDING_USER),
-      map(() => new fromRoot.Go({ path: ['users/invite-user'] }))
+      switchMap(() => {
+        return this.appStore.pipe(
+          select(fromRoot.getOgdInviteUserFlowFeatureIsEnabled),
+          take(1),
+          map((isEnabled) => {
+            if (isEnabled) {
+              return new fromRoot.Go({ path: ['users/manage'] });
+            }
+            return new fromRoot.Go({ path: ['users/invite-user'] });
+          })
+        );
+      })
     )
   );
 }

--- a/src/users/store/reducers/users.reducer.ts
+++ b/src/users/store/reducers/users.reducer.ts
@@ -113,7 +113,8 @@ export function reducer(
     case fromUsers.INVITE_NEW_USER: {
       return {
         ...state,
-        reinvitePendingUser: null
+        reinvitePendingUser: null,
+        userDetails: null
       };
     }
 

--- a/src/users/users.routing.ts
+++ b/src/users/users.routing.ts
@@ -43,6 +43,11 @@ export const ROUTES: Routes = [
     path: 'user/:userId/manage',
     component: ManageUserComponent,
     canActivate: [featureToggleOdgInviteUserFlowGuard]
+  },
+  {
+    path: 'manage',
+    component: ManageUserComponent,
+    canActivate: [featureToggleOdgInviteUserFlowGuard]
   }
 ];
 


### PR DESCRIPTION
### Jira link (if applicable)

[GA-76](https://tools.hmcts.net/jira/browse/GA-76)

### Change description ###

When the `ogd-invite-user-flow` is enabled, the invite button should redirect user to the new manage user component with an empty form and the latest access types

______________

<img width="750" alt="image" src="https://github.com/hmcts/rpx-xui-manage-organisations/assets/41630528/daec98a8-945d-4f51-bb10-cb6229a1fc6a">
