### PR TITLE
EXUI-4360: migrate organisation details journey

### DIFF
--- a/playwright_tests_new/E2E/fixtures.ts
+++ b/playwright_tests_new/E2E/fixtures.ts
@@ -1,5 +1,5 @@
 import { test as base, expect } from '@playwright/test';
-import type { BrowserContext, Page } from '@playwright/test';
+import type { BrowserContext, Locator, Page } from '@playwright/test';
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -101,6 +101,15 @@ const applyStoredAuthState = async (page: Page, storageStatePath: string): Promi
   }
 };
 
+const isVisibleWithin = async (locator: Locator, timeout: number): Promise<boolean> => {
+  try {
+    await locator.waitFor({ state: 'visible', timeout });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export const test = base.extend<PageFixtures & AuthFixtures, AuthWorkerFixtures>({
   ...pageFixtures,
   manageOrgStorageStatePath: [async ({ browserName }, use, workerInfo) => {
@@ -120,15 +129,18 @@ export const test = base.extend<PageFixtures & AuthFixtures, AuthWorkerFixtures>
   },
   signedInPage: async ({ page, idamPage, manageOrgStorageStatePath }, use) => {
     const testUser = resolveTestUser(resolveConfiguredUserRole());
+    const organisationLink = page.getByRole('link', { name: 'Organisation', exact: true });
     await applyStoredAuthState(page, manageOrgStorageStatePath);
     await page.goto('');
-    if (page.url().includes('/login')) {
+    if (!await isVisibleWithin(organisationLink, 10_000)) {
       await page.context().clearCookies();
+      await page.goto('');
+      await expect(idamPage.heading).toBeVisible();
       await idamPage.signIn(testUser.email, testUser.password);
-      await expect(page.getByRole('link', { name: 'Organisation', exact: true })).toBeVisible();
+      await expect(organisationLink).toBeVisible();
       await page.context().storageState({ path: manageOrgStorageStatePath });
     }
-    await expect(page.getByRole('link', { name: 'Organisation', exact: true })).toBeVisible();
+    await expect(organisationLink).toBeVisible();
     await use(page);
   }
 });

--- a/playwright_tests_new/E2E/page-objects/pages/idam.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/idam.po.ts
@@ -10,7 +10,7 @@ export class IdamPage extends BasePage {
     await this.usernameInput.fill(username);
     await this.passwordInput.fill(password);
     await Promise.all([
-      this.page.waitForURL((url) => url.pathname !== '/login'),
+      this.page.waitForURL((url) => !url.hostname.includes('idam') && !url.pathname.includes('/login')),
       this.submitBtn.click()
     ]);
     await this.page.waitForLoadState('domcontentloaded');

--- a/playwright_tests_new/E2E/page-objects/pages/organisation.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/organisation.po.ts
@@ -1,0 +1,21 @@
+import type { Locator } from '@playwright/test';
+import { BasePage } from '../base';
+
+export class OrganisationPage extends BasePage {
+  public readonly heading = this.page.getByRole('heading', { name: 'Organisation' });
+  public readonly root = this.page.locator('app-prd-organisation-component');
+
+  public async open(): Promise<void> {
+    await this.page.getByRole('link', { name: 'Organisation', exact: true }).click();
+  }
+
+  public summaryValue(label: RegExp): Locator {
+    const summaryRow = this.root
+      .locator('.govuk-summary-list__row, .govuk-table__row')
+      .filter({
+        has: this.page.locator('.govuk-summary-list__key, .govuk-table__header', { hasText: label })
+      });
+
+    return summaryRow.locator('.govuk-summary-list__value, .govuk-table__cell');
+  }
+}

--- a/playwright_tests_new/E2E/page-objects/pages/page.fixtures.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/page.fixtures.ts
@@ -1,12 +1,17 @@
 import type { Page } from '@playwright/test';
 import { IdamPage } from './idam.po';
+import { OrganisationPage } from './organisation.po';
 
 export interface PageFixtures {
   idamPage: IdamPage;
+  organisationPage: OrganisationPage;
 }
 
 export const pageFixtures = {
   idamPage: async ({ page }: { page: Page }, use: (value: IdamPage) => Promise<void>) => {
     await use(new IdamPage(page));
+  },
+  organisationPage: async ({ page }: { page: Page }, use: (value: OrganisationPage) => Promise<void>) => {
+    await use(new OrganisationPage(page));
   }
 };

--- a/playwright_tests_new/E2E/test/core/organisation-details.spec.ts
+++ b/playwright_tests_new/E2E/test/core/organisation-details.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '../../fixtures';
+
+type OrganisationApiResponse = {
+  name: string;
+  contactInformation: Array<{
+    addressLine1?: string;
+  }>;
+};
+
+test('displays authenticated organisation name and address details', async ({ signedInPage, organisationPage }) => {
+  const organisationResponse = await signedInPage.request.get('/api/organisation');
+  expect(organisationResponse.ok()).toBeTruthy();
+  const expectedOrganisation = await organisationResponse.json() as OrganisationApiResponse;
+  expect(expectedOrganisation.contactInformation.length).toBeGreaterThan(0);
+  const expectedContactInformation = expectedOrganisation.contactInformation[0];
+  expect(expectedContactInformation.addressLine1).toBeTruthy();
+
+  await organisationPage.open();
+
+  await expect(organisationPage.heading).toBeVisible();
+  await expect(organisationPage.root).toBeVisible();
+  await expect(organisationPage.summaryValue(/^Name$/)).toContainText(expectedOrganisation.name);
+  await expect(organisationPage.summaryValue(/^(Organisation address|Address)$/)).toContainText(
+    expectedContactInformation.addressLine1 as string
+  );
+});


### PR DESCRIPTION
### Jira link

See [EXUI-4360](https://tools.hmcts.net/jira/browse/EXUI-4360)

### Change description ###

This PR migrates the approved Phase 5 organisation-details journey from the legacy flaky Codecept estate into the new `playwright_tests_new/E2E` Playwright framework.

Changes included:

- Adds a new `playwright_tests_new/E2E/test/core/organisation-details.spec.ts` coverage point for the authenticated Organisation page.
- Adds an `OrganisationPage` page object and fixture wiring so the Organisation page can be reused by later migrated core journey specs.
- Asserts live organisation data loaded from `/api/organisation`, including the organisation name and address value, instead of only checking that static labels render.
- Hardens the shared `signedInPage` fixture so it supports both fresh login and cached storage-state reuse without treating a login redirect as an authenticated session.
- Tightens `IdamPage.signIn()` so it waits until the browser has genuinely left both IDAM and ManageOrg login routes before continuing.

### Value added ###

- **Closes an approved migration gap:** delivers the EXUI-4360 Phase 5 `viewOrganisation.feature` intent in the new Playwright framework rather than leaving it in the flaky legacy Codecept pack.
- **Improves confidence in live coverage:** the test proves that authenticated users can open Organisation details and see real API-backed organisation data, not just that the page shell or GOV.UK summary-list labels exist.
- **Reduces false positives:** asserting the organisation name and address value would catch data-loading, API-contract, resolver, or template-binding regressions that the old shallow label checks would miss.
- **Strengthens the shared migration foundation:** the auth fixture now handles both first-run login and reused storage state, which benefits the next EXUI-4360 core journey migrations using the same `signedInPage` pattern.
- **Keeps the migration maintainable:** Organisation navigation and summary-list access are centralised in a page object, reducing selector duplication as more journeys move into `playwright_tests_new/E2E`.
- **Aligns with the agreed migration direction:** the work lands in the new Playwright framework and keeps legacy cleanup or wider Codecept retirement out of this PR.

### Scope boundaries ###

- This PR does not remove legacy Codecept coverage.
- This PR does not change Jenkins, Pact, old functional test publishing, or API-functional report generation.
- Follow-on EXUI-4360 work can build on the new Organisation page object for additional core journeys.

### Testing done

- [x] `node .yarn/releases/yarn-4.9.2.cjs eslint playwright_tests_new/E2E/fixtures.ts playwright_tests_new/E2E/page-objects/pages/idam.po.ts playwright_tests_new/E2E/page-objects/pages/page.fixtures.ts playwright_tests_new/E2E/page-objects/pages/organisation.po.ts playwright_tests_new/E2E/test/core/organisation-details.spec.ts`
- [x] `node .yarn/releases/yarn-4.9.2.cjs playwright test playwright_tests_new/E2E/test/core/organisation-details.spec.ts --project=chromium --list`
- [x] `git diff --check`
- [x] `MANAGE_ORG_STORAGE_STATE=/tmp/rpx-xui-manage-organisations-exui-4360-rerun PLAYWRIGHT_REPORTERS=list node -r dotenv-extended/config .yarn/releases/yarn-4.9.2.cjs playwright test playwright_tests_new/E2E/test/core/organisation-details.spec.ts --project=chromium`
- [x] Cached-state repeat of the same live AAT command
- [x] `node .yarn/releases/yarn-4.9.2.cjs lint`

### CI note ###

The Jenkins PR-head failure was reviewed separately. The failing tail is in the existing legacy functional/API report publishing path where `reports/tests/api_functional` and `reports/tests/functional` were missing after an empty-run check. The PR-specific preview functional and AKS smoke checks passed, and this PR does not touch that Jenkins/reporting path.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

No dependencies, secrets, or CVE suppressions are introduced. The test reads credentials from the existing ignored `.env`/environment contract only.

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
