### PR TITLE
EXUI-4362: migrate register other org happy path

### DIFF
--- a/playwright_tests_new/E2E/page-objects/pages/organisation.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/organisation.po.ts
@@ -11,11 +11,11 @@ export class OrganisationPage extends BasePage {
 
   public summaryValue(label: RegExp): Locator {
     const summaryRow = this.root
-      .locator('.govuk-summary-list__row, .govuk-table__row')
+      .locator('.govuk-summary-list__row')
       .filter({
-        has: this.page.locator('.govuk-summary-list__key, .govuk-table__header', { hasText: label })
+        has: this.page.locator('.govuk-summary-list__key', { hasText: label })
       });
 
-    return summaryRow.locator('.govuk-summary-list__value, .govuk-table__cell');
+    return summaryRow.locator('.govuk-summary-list__value');
   }
 }

--- a/playwright_tests_new/E2E/page-objects/pages/register-organisation.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/register-organisation.po.ts
@@ -183,6 +183,10 @@ export class RegisterOrganisationPage extends BasePage {
     return this.summaryRow(label).locator('.govuk-summary-list__value');
   }
 
+  public summaryChangeLink(label: string | RegExp): Locator {
+    return this.summaryRow(label).locator('.govuk-summary-list__actions a');
+  }
+
   public summaryRow(label: string | RegExp): Locator {
     const keyText = typeof label === 'string' ? new RegExp(`^\\s*${escapeRegExp(label)}\\s*$`) : label;
 

--- a/playwright_tests_new/E2E/page-objects/pages/register-organisation.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/register-organisation.po.ts
@@ -81,6 +81,11 @@ export class RegisterOrganisationPage extends BasePage {
     await this.continueWith();
   }
 
+  public async declineDocumentExchangeReference(): Promise<void> {
+    await this.page.locator('#document-exchange-no').check();
+    await this.continueWith();
+  }
+
   public async enterOrganisationRegulator(registrationNumber: string): Promise<void> {
     await this.page.locator('#regulator-type0').selectOption({ label: 'Solicitor Regulation Authority (SRA)' });
     await this.page.locator('#organisation-registration-number0').fill(registrationNumber);
@@ -151,11 +156,15 @@ export class RegisterOrganisationPage extends BasePage {
   }
 
   public summaryValue(label: string | RegExp): Locator {
+    return this.summaryRow(label).locator('.govuk-summary-list__value');
+  }
+
+  public summaryRow(label: string | RegExp): Locator {
     const keyText = typeof label === 'string' ? new RegExp(`^\\s*${escapeRegExp(label)}\\s*$`) : label;
 
     return this.page.locator('.govuk-summary-list__row').filter({
       has: this.page.locator('.govuk-summary-list__key', { hasText: keyText })
-    }).locator('.govuk-summary-list__value');
+    });
   }
 
   private async continueWith(buttonName = 'Continue'): Promise<void> {

--- a/playwright_tests_new/E2E/page-objects/pages/register-organisation.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/register-organisation.po.ts
@@ -7,6 +7,16 @@ type ContactDetails = {
   email: string;
 };
 
+type ManualAddress = {
+  line1: string;
+  line2?: string;
+  line3?: string;
+  town: string;
+  county?: string;
+  postcode?: string;
+  country: string;
+};
+
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export class RegisterOrganisationPage extends BasePage {
@@ -71,6 +81,20 @@ export class RegisterOrganisationPage extends BasePage {
     await addressList.selectOption({ index: 1 });
     await this.continueWith();
     return selectedAddress;
+  }
+
+  public async enterManualUkAddress(address: ManualAddress): Promise<void> {
+    await this.page.getByRole('link', { name: 'I can\'t enter a UK postcode' }).click();
+    await this.page.locator('#yes').check();
+    await this.fillManualAddress(address);
+    await this.continueWith();
+  }
+
+  public async enterManualInternationalAddress(address: ManualAddress): Promise<void> {
+    await this.page.getByRole('link', { name: 'I can\'t enter a UK postcode' }).click();
+    await this.page.locator('#no').check();
+    await this.fillManualAddress(address);
+    await this.continueWith();
   }
 
   public async enterDocumentExchangeReference(dxNumber: string, dxExchange: string): Promise<void> {
@@ -169,5 +193,19 @@ export class RegisterOrganisationPage extends BasePage {
 
   private async continueWith(buttonName = 'Continue'): Promise<void> {
     await this.page.getByRole('button', { name: buttonName }).click();
+  }
+
+  private async fillManualAddress(address: ManualAddress): Promise<void> {
+    await this.page.locator('#addressLine1').fill(address.line1);
+    await this.page.locator('#addressLine2').fill(address.line2 ?? '');
+    await this.page.locator('#addressLine3').fill(address.line3 ?? '');
+    await this.page.locator('#postTown').fill(address.town);
+    await this.page.locator('#county').fill(address.county ?? '');
+
+    if (address.country !== 'UK') {
+      await this.page.locator('#country').fill(address.country);
+    }
+
+    await this.page.locator('#postCode').fill(address.postcode ?? '');
   }
 }

--- a/playwright_tests_new/E2E/page-objects/pages/register-organisation.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/register-organisation.po.ts
@@ -49,6 +49,12 @@ export class RegisterOrganisationPage extends BasePage {
     await this.continueWith();
   }
 
+  public async enterOrganisationNameAndCompanyHouseNumber(organisationName: string, companyHouseNumber: string): Promise<void> {
+    await this.page.locator('#company-name').fill(organisationName);
+    await this.page.locator('#company-house-number').fill(companyHouseNumber);
+    await this.continueWith();
+  }
+
   public async selectRegisteredAddress(postcode: string): Promise<string> {
     await this.page.locator('#postcodeInput').fill(postcode);
     await this.page.getByRole('button', { name: 'Find address' }).click();
@@ -81,13 +87,40 @@ export class RegisterOrganisationPage extends BasePage {
     await this.continueWith();
   }
 
+  public async enterOtherOrganisationRegulator(regulatorName: string, registrationNumber: string): Promise<void> {
+    await this.page.locator('#regulator-type0').selectOption({ label: 'Other' });
+    await this.page.locator('#regulator-name0').fill(regulatorName);
+    await this.page.locator('#organisation-registration-number0').fill(registrationNumber);
+    await this.continueWith();
+  }
+
   public async chooseDivorceService(): Promise<void> {
     await this.page.locator('input[data-service-label="Divorce"]').check();
     await this.continueWith();
   }
 
+  public async chooseServices(...serviceLabels: string[]): Promise<void> {
+    for (const serviceLabel of serviceLabels) {
+      await this.page.locator(`input[data-service-label="${serviceLabel}"]`).check();
+    }
+    await this.continueWith();
+  }
+
   public async declinePaymentByAccount(): Promise<void> {
     await this.page.locator('#pba-no').check();
+    await this.continueWith();
+  }
+
+  public async enterPaymentByAccountNumbers(pbaNumbers: string[]): Promise<void> {
+    await this.page.locator('#pba-yes').check();
+    await this.continueWith();
+
+    for (const [index, pbaNumber] of pbaNumbers.entries()) {
+      if (index > 0) {
+        await this.page.getByRole('button', { name: 'Add another PBA number' }).click();
+      }
+      await this.page.locator(`#pba-number-${index}`).fill(pbaNumber);
+    }
     await this.continueWith();
   }
 
@@ -100,6 +133,15 @@ export class RegisterOrganisationPage extends BasePage {
 
   public async declineIndividualRegulator(): Promise<void> {
     await this.page.locator('#registered-with-regulator-no').check();
+    await this.continueWith();
+  }
+
+  public async enterOtherIndividualRegulator(regulatorName: string, registrationNumber: string): Promise<void> {
+    await this.page.locator('#registered-with-regulator-yes').check();
+    await this.continueWith();
+    await this.page.locator('#regulator-type0').selectOption({ label: 'Other' });
+    await this.page.locator('#regulator-name0').fill(regulatorName);
+    await this.page.locator('#organisation-registration-number0').fill(registrationNumber);
     await this.continueWith();
   }
 

--- a/playwright_tests_new/E2E/test/registration/register-organisation.spec.ts
+++ b/playwright_tests_new/E2E/test/registration/register-organisation.spec.ts
@@ -30,7 +30,7 @@ test(
     await registerOrganisationPage.startRegistration();
     await registerOrganisationPage.chooseSolicitorOrganisationType();
     await registerOrganisationPage.enterOrganisationName(data.organisationName);
-    const selectedAddress = await registerOrganisationPage.selectRegisteredAddress(data.postcode);
+    const selectedAddress = await registerOrganisationPage.selectRegisteredAddress(data.lookupPostcode);
     await registerOrganisationPage.enterDocumentExchangeReference(data.dxNumber, data.dxExchange);
     await registerOrganisationPage.enterOrganisationRegulator(data.regulatorNumber);
     await registerOrganisationPage.chooseDivorceService();
@@ -73,7 +73,7 @@ test(
     await registerOrganisationPage.startRegistration();
     await registerOrganisationPage.chooseSolicitorOrganisationType();
     await registerOrganisationPage.enterOrganisationNameAndCompanyHouseNumber(data.organisationName, data.companyHouseNumber);
-    const selectedAddress = await registerOrganisationPage.selectRegisteredAddress(data.postcode);
+    await registerOrganisationPage.enterManualUkAddress(data.manualUkAddress);
     await registerOrganisationPage.enterDocumentExchangeReference(data.dxNumber, data.dxExchange);
     await registerOrganisationPage.enterOtherOrganisationRegulator(data.regulatorName, data.regulatorNumber);
     await registerOrganisationPage.chooseServices('Divorce', 'Damages');
@@ -85,7 +85,18 @@ test(
     await expect(registerOrganisationPage.summaryValue('Organisation type')).toContainText('Solicitor');
     await expect(registerOrganisationPage.summaryValue('Organisation name')).toContainText(data.organisationName);
     await expect(registerOrganisationPage.summaryValue('Company registration number')).toContainText(data.companyHouseNumber);
-    await expect(registerOrganisationPage.summaryValue('Organisation address')).toContainText(selectedAddress.split(',')[0]);
+    const ukAddressSummary = registerOrganisationPage.summaryValue('Organisation address');
+    for (const addressLine of [
+      data.manualUkAddress.line1,
+      data.manualUkAddress.line2,
+      data.manualUkAddress.line3,
+      data.manualUkAddress.town,
+      data.manualUkAddress.county,
+      data.manualUkAddress.postcode,
+      data.manualUkAddress.country
+    ].filter((addressLine): addressLine is string => Boolean(addressLine))) {
+      await expect(ukAddressSummary).toContainText(addressLine);
+    }
     await expect(registerOrganisationPage.summaryValue(
       'Do you have a document exchange reference for your main office?'
     )).toContainText('Yes');
@@ -125,7 +136,7 @@ test(
     await registerOrganisationPage.startRegistration();
     await registerOrganisationPage.chooseSolicitorOrganisationType();
     await registerOrganisationPage.enterOrganisationName(data.organisationName);
-    const selectedAddress = await registerOrganisationPage.selectRegisteredAddress(data.postcode);
+    await registerOrganisationPage.enterManualInternationalAddress(data.manualInternationalAddress);
     await registerOrganisationPage.declineDocumentExchangeReference();
     await registerOrganisationPage.enterOrganisationRegulator(data.regulatorNumber);
     await registerOrganisationPage.chooseServices('Divorce', 'Damages');
@@ -137,7 +148,14 @@ test(
     await expect(registerOrganisationPage.summaryValue('Organisation type')).toContainText('Solicitor');
     await expect(registerOrganisationPage.summaryValue('Organisation name')).toContainText(data.organisationName);
     await expect(registerOrganisationPage.summaryRow('Company registration number')).toHaveCount(0);
-    await expect(registerOrganisationPage.summaryValue('Organisation address')).toContainText(selectedAddress.split(',')[0]);
+    const internationalAddressSummary = registerOrganisationPage.summaryValue('Organisation address');
+    for (const addressLine of [
+      data.manualInternationalAddress.line1,
+      data.manualInternationalAddress.town,
+      data.manualInternationalAddress.country
+    ]) {
+      await expect(internationalAddressSummary).toContainText(addressLine);
+    }
     await expect(registerOrganisationPage.summaryValue(
       'Do you have a document exchange reference for your main office?'
     )).toContainText('No');

--- a/playwright_tests_new/E2E/test/registration/register-organisation.spec.ts
+++ b/playwright_tests_new/E2E/test/registration/register-organisation.spec.ts
@@ -59,3 +59,55 @@ test(
     await expect(registerOrganisationPage.submittedHeading).toBeVisible({ timeout: 30_000 });
   }
 );
+
+test(
+  'checks optional register-org-new details before submission',
+  { tag: ['@e2e', '@registration'] },
+  async ({ signedInPage, registerOrganisationPage }) => {
+    const data = createRegisterOrganisationData();
+
+    await registerOrganisationPage.openStartPage();
+    await expect(signedInPage).toHaveURL(/\/register-org-new\/register$/);
+    await expect(registerOrganisationPage.startPageHeading).toBeVisible();
+
+    await registerOrganisationPage.startRegistration();
+    await registerOrganisationPage.chooseSolicitorOrganisationType();
+    await registerOrganisationPage.enterOrganisationNameAndCompanyHouseNumber(data.organisationName, data.companyHouseNumber);
+    const selectedAddress = await registerOrganisationPage.selectRegisteredAddress(data.postcode);
+    await registerOrganisationPage.enterDocumentExchangeReference(data.dxNumber, data.dxExchange);
+    await registerOrganisationPage.enterOtherOrganisationRegulator(data.regulatorName, data.regulatorNumber);
+    await registerOrganisationPage.chooseServices('Divorce', 'Damages');
+    await registerOrganisationPage.enterPaymentByAccountNumbers(data.pbaNumbers);
+    await registerOrganisationPage.enterContactDetails(data);
+    await registerOrganisationPage.enterOtherIndividualRegulator(data.individualRegulatorName, data.individualRegulatorNumber);
+
+    await expect(registerOrganisationPage.checkYourAnswersHeading).toBeVisible();
+    await expect(registerOrganisationPage.summaryValue('Organisation type')).toContainText('Solicitor');
+    await expect(registerOrganisationPage.summaryValue('Organisation name')).toContainText(data.organisationName);
+    await expect(registerOrganisationPage.summaryValue('Company registration number')).toContainText(data.companyHouseNumber);
+    await expect(registerOrganisationPage.summaryValue('Organisation address')).toContainText(selectedAddress.split(',')[0]);
+    await expect(registerOrganisationPage.summaryValue(
+      'Do you have a document exchange reference for your main office?'
+    )).toContainText('Yes');
+    await expect(registerOrganisationPage.summaryValue('What\'s the DX reference for this office?')).toContainText(data.dxNumber);
+    await expect(registerOrganisationPage.summaryValue('Service to access')).toContainText('Divorce');
+    await expect(registerOrganisationPage.summaryValue('Service to access')).toContainText('Damages');
+    await expect(registerOrganisationPage.summaryValue('Does your organisation have a payment by account number?')).toContainText('Yes');
+    await expect(registerOrganisationPage.summaryValue('What PBA numbers does your organisation use?')).toContainText(data.pbaNumbers[0]);
+    await expect(registerOrganisationPage.summaryValue('What PBA numbers does your organisation use?')).toContainText(data.pbaNumbers[1]);
+    await expect(registerOrganisationPage.summaryValue('Regulatory organisation type')).toContainText(data.regulatorName);
+    await expect(registerOrganisationPage.summaryValue('Regulatory organisation type')).toContainText(data.regulatorNumber);
+    await expect(registerOrganisationPage.summaryValue('First name(s)')).toContainText(data.firstName);
+    await expect(registerOrganisationPage.summaryValue('Last name')).toContainText(data.lastName);
+    await expect(registerOrganisationPage.summaryValue('Email address')).toContainText(data.email);
+    await expect(registerOrganisationPage.summaryValue(
+      'Are you (as an individual) registered with a regulator?'
+    )).toContainText('Yes');
+    await expect(registerOrganisationPage.summaryValue(
+      'What regulators are you (as an individual) registered with?'
+    )).toContainText(data.individualRegulatorName);
+    await expect(registerOrganisationPage.summaryValue(
+      'What regulators are you (as an individual) registered with?'
+    )).toContainText(data.individualRegulatorNumber);
+  }
+);

--- a/playwright_tests_new/E2E/test/registration/register-organisation.spec.ts
+++ b/playwright_tests_new/E2E/test/registration/register-organisation.spec.ts
@@ -120,6 +120,23 @@ test(
     await expect(registerOrganisationPage.summaryValue(
       'What regulators are you (as an individual) registered with?'
     )).toContainText(data.individualRegulatorNumber);
+
+    for (const summaryLabel of [
+      'Organisation type',
+      'Organisation name',
+      'Company registration number',
+      'Organisation address',
+      'What\'s the DX reference for this office?',
+      'Service to access',
+      'Does your organisation have a payment by account number?',
+      'Regulatory organisation type',
+      'First name(s)',
+      'Last name',
+      'Email address',
+      'What regulators are you (as an individual) registered with?'
+    ]) {
+      await expect(registerOrganisationPage.summaryChangeLink(summaryLabel)).toBeVisible();
+    }
   }
 );
 

--- a/playwright_tests_new/E2E/test/registration/register-organisation.spec.ts
+++ b/playwright_tests_new/E2E/test/registration/register-organisation.spec.ts
@@ -111,3 +111,50 @@ test(
     )).toContainText(data.individualRegulatorNumber);
   }
 );
+
+test(
+  'checks minimum register-org-new details before submission',
+  { tag: ['@e2e', '@registration'] },
+  async ({ signedInPage, registerOrganisationPage }) => {
+    const data = createRegisterOrganisationData();
+
+    await registerOrganisationPage.openStartPage();
+    await expect(signedInPage).toHaveURL(/\/register-org-new\/register$/);
+    await expect(registerOrganisationPage.startPageHeading).toBeVisible();
+
+    await registerOrganisationPage.startRegistration();
+    await registerOrganisationPage.chooseSolicitorOrganisationType();
+    await registerOrganisationPage.enterOrganisationName(data.organisationName);
+    const selectedAddress = await registerOrganisationPage.selectRegisteredAddress(data.postcode);
+    await registerOrganisationPage.declineDocumentExchangeReference();
+    await registerOrganisationPage.enterOrganisationRegulator(data.regulatorNumber);
+    await registerOrganisationPage.chooseServices('Divorce', 'Damages');
+    await registerOrganisationPage.declinePaymentByAccount();
+    await registerOrganisationPage.enterContactDetails(data);
+    await registerOrganisationPage.declineIndividualRegulator();
+
+    await expect(registerOrganisationPage.checkYourAnswersHeading).toBeVisible();
+    await expect(registerOrganisationPage.summaryValue('Organisation type')).toContainText('Solicitor');
+    await expect(registerOrganisationPage.summaryValue('Organisation name')).toContainText(data.organisationName);
+    await expect(registerOrganisationPage.summaryRow('Company registration number')).toHaveCount(0);
+    await expect(registerOrganisationPage.summaryValue('Organisation address')).toContainText(selectedAddress.split(',')[0]);
+    await expect(registerOrganisationPage.summaryValue(
+      'Do you have a document exchange reference for your main office?'
+    )).toContainText('No');
+    await expect(registerOrganisationPage.summaryRow('What\'s the DX reference for this office?')).toHaveCount(0);
+    await expect(registerOrganisationPage.summaryValue('Service to access')).toContainText('Divorce');
+    await expect(registerOrganisationPage.summaryValue('Service to access')).toContainText('Damages');
+    await expect(registerOrganisationPage.summaryValue('Does your organisation have a payment by account number?')).toContainText('No');
+    await expect(registerOrganisationPage.summaryRow('What PBA numbers does your organisation use?')).toHaveCount(0);
+    await expect(registerOrganisationPage.summaryValue('Regulatory organisation type')).toContainText(data.regulatorNumber);
+    await expect(registerOrganisationPage.summaryValue('First name(s)')).toContainText(data.firstName);
+    await expect(registerOrganisationPage.summaryValue('Last name')).toContainText(data.lastName);
+    await expect(registerOrganisationPage.summaryValue('Email address')).toContainText(data.email);
+    await expect(registerOrganisationPage.summaryValue(
+      'Are you (as an individual) registered with a regulator?'
+    )).toContainText('No');
+    await expect(registerOrganisationPage.summaryRow(
+      'What regulators are you (as an individual) registered with?'
+    )).toHaveCount(0);
+  }
+);

--- a/playwright_tests_new/E2E/utils/test-setup/register-organisation-data.ts
+++ b/playwright_tests_new/E2E/utils/test-setup/register-organisation-data.ts
@@ -1,12 +1,17 @@
 export type RegisterOrganisationData = {
   organisationName: string;
+  companyHouseNumber: string;
   postcode: string;
   dxNumber: string;
   dxExchange: string;
   regulatorNumber: string;
+  regulatorName: string;
+  pbaNumbers: string[];
   firstName: string;
   lastName: string;
   email: string;
+  individualRegulatorName: string;
+  individualRegulatorNumber: string;
 };
 
 const randomDigits = (length: number): string => {
@@ -22,12 +27,17 @@ export const createRegisterOrganisationData = (): RegisterOrganisationData => {
 
   return {
     organisationName: `PW ManageOrg ${uniqueId}`,
+    companyHouseNumber: randomDigits(8),
     postcode: 'SW1A 1AA',
     dxNumber: randomDigits(10),
     dxExchange: randomDigits(10),
     regulatorNumber: randomDigits(10),
+    regulatorName: `PW regulator ${randomDigits(5)}`,
+    pbaNumbers: [`PBA${randomDigits(7)}`, `PBA${randomDigits(7)}`],
     firstName: 'Playwright',
     lastName: `User${randomDigits(5)}`,
-    email: `pw.manageorg.${uniqueId}@example.com`
+    email: `pw.manageorg.${uniqueId}@example.com`,
+    individualRegulatorName: `PW individual regulator ${randomDigits(5)}`,
+    individualRegulatorNumber: randomDigits(8)
   };
 };

--- a/playwright_tests_new/E2E/utils/test-setup/register-organisation-data.ts
+++ b/playwright_tests_new/E2E/utils/test-setup/register-organisation-data.ts
@@ -1,7 +1,9 @@
 export type RegisterOrganisationData = {
   organisationName: string;
   companyHouseNumber: string;
-  postcode: string;
+  lookupPostcode: string;
+  manualUkAddress: RegisterOrganisationAddress;
+  manualInternationalAddress: RegisterOrganisationAddress;
   dxNumber: string;
   dxExchange: string;
   regulatorNumber: string;
@@ -12,6 +14,16 @@ export type RegisterOrganisationData = {
   email: string;
   individualRegulatorName: string;
   individualRegulatorNumber: string;
+};
+
+export type RegisterOrganisationAddress = {
+  line1: string;
+  line2?: string;
+  line3?: string;
+  town: string;
+  county?: string;
+  postcode?: string;
+  country: string;
 };
 
 const randomDigits = (length: number): string => {
@@ -28,7 +40,21 @@ export const createRegisterOrganisationData = (): RegisterOrganisationData => {
   return {
     organisationName: `PW ManageOrg ${uniqueId}`,
     companyHouseNumber: randomDigits(8),
-    postcode: 'SW1A 1AA',
+    lookupPostcode: 'SW1A 1AA',
+    manualUkAddress: {
+      line1: `PW building ${uniqueId}`,
+      line2: 'PW address line 2',
+      line3: 'PW address line 3',
+      town: 'London',
+      county: 'Greater London',
+      postcode: 'SW1V 3BZ',
+      country: 'UK'
+    },
+    manualInternationalAddress: {
+      line1: `PW international building ${uniqueId}`,
+      town: 'Dublin',
+      country: 'Ireland'
+    },
     dxNumber: randomDigits(10),
     dxExchange: randomDigits(10),
     regulatorNumber: randomDigits(10),


### PR DESCRIPTION
### Jira link

See [EXUI-4362](https://tools.hmcts.net/jira/browse/EXUI-4362)

### Change description ###

- Adds follow-on registration coverage under `EXUI-4362` for the legacy ignored register-other-org happy paths.
- Extends the new-framework register organisation page object with focused methods for postcode lookup, manual UK address entry, manual non-UK address entry, optional Companies House, DX reference, other regulator, multi-service, PBA, individual regulator, and no-DX flows.
- Extends registration test data with deterministic optional fields and manual-address data while preserving unique organisation/email generation.
- Adds CYA-focused coverage for both optional-details and minimum-details register-org-new journeys.
- Adds CYA change-link presence checks for the migrated optional-summary rows, covering the low-risk part of the legacy register-other-org navigation intent without adding another submitted journey.
- Hardens the organisation-details page object so full migrated E2E evidence is not blocked by duplicate `Name` matches across summary lists and tables.
- Keeps final submit in the existing core happy path and stops the optional/minimum CYA variants before submission to avoid unnecessary AAT data mutation.

Added value to the test pack:

- Moves the ignored legacy Codecept register-other-org happy-path intent into `playwright_tests_new/E2E` without expanding the old suite.
- Covers optional business-critical registration data that the previous merged happy path did not prove: Companies House number, DX reference, PBA numbers, multiple service selections, organisation regulator, and individual regulator details.
- Preserves the legacy address-path intent: the optional-values scenario uses manual UK address entry after `I can't enter a UK postcode`, and the minimum-values scenario uses manual non-UK address entry.
- Covers the minimum-data path and asserts skipped optional answers do not appear on CYA, which protects against false-positive summary rendering and accidental optional-field leakage.
- Confirms CYA rows expose change links for the migrated optional answers, protecting the user’s ability to correct registration details before submission.
- Keeps the existing organisation-details migration stable by scoping detail assertions to the GOV.UK summary list rather than accidentally matching office table rows.
- Raises the migrated CNP E2E pack from 4 to 6 Chromium journeys while keeping the scope inside the existing registration migration ticket.
- Preserves the Phase 6 boundary: page-level validations, back-link workflow, and change-link-and-continue navigation remain separate follow-on work.

### Testing done

Automated:

- [x] `git diff --check`
- [x] `yarn lint`
- [x] `yarn playwright test playwright_tests_new/E2E/test/registration/register-organisation.spec.ts --project=chromium --list` listed 4 registration tests
- [x] `yarn playwright test playwright_tests_new/E2E/test/registration/register-organisation.spec.ts --project=chromium --workers=1 --retries=0` passed 4 registration tests
- [x] `yarn playwright test playwright_tests_new/E2E/test/core/organisation-details.spec.ts --project=chromium --workers=1 --retries=0` passed 1 core organisation-details test
- [x] `yarn test:playwrightE2E:list` listed 6 migrated Chromium journeys
- [x] `yarn test:playwrightE2E:raw -- --workers=1 --retries=0` passed 6 migrated Chromium journeys

Manual:

- [x] Confirmed no secret values are staged or committed.
- [x] Confirmed workspace traceability remains outside the repo branch under `.workspace-traceability`.
- [x] Confirmed active traceability source is the Jira-key bundle: `.workspace-traceability/repos/rpx-xui-manage-organisations/active/EXUI-4362`.

Evidence:

- HTML: `functional-output/tests/playwright-e2e/index.html`
- Odhin: N/A for local raw run
- JUnit: N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change: No
