### PR TITLE
EXUI-4358 Add assigned cases Playwright integration parity

### DIFF
--- a/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
@@ -4,7 +4,10 @@ import type {
   CaseSharingSharedCase
 } from '../mocks/caseSharing.mock';
 import {
+  assignedCaseTypesResponse,
+  asylumCaseType,
   buildCaseAssignmentSuccessResponse,
+  buildAssignedCasesResponse,
   buildSharedCases,
   petSolicitorTwo,
   unassignedCasesResponse,
@@ -30,6 +33,11 @@ export interface UnassignedCaseShareRouteState {
   caseTypesRequests: CaseTypesRequest[];
   loadedShareCaseIds: string[][];
   submittedAssignments: CaseAssignmentsRequest[];
+}
+
+export interface AssignedCaseRouteState {
+  caseListRequests: CaseListRequest[];
+  caseTypesRequests: CaseTypesRequest[];
 }
 
 const routeUrl = (requestUrl: string): URL => new URL(requestUrl);
@@ -95,6 +103,43 @@ export const setupUnassignedCaseShareRoutes = async (
     routeState.assignmentResponses.push(responseBody);
 
     await fulfillJson(route, responseBody);
+  });
+
+  return routeState;
+};
+
+export const setupAssignedCaseRoutes = async (page: Page): Promise<AssignedCaseRouteState> => {
+  const routeState: AssignedCaseRouteState = {
+    caseListRequests: [],
+    caseTypesRequests: []
+  };
+
+  await page.route('**/api/caaCaseTypes**', async (route) => {
+    const url = routeUrl(route.request().url());
+
+    routeState.caseTypesRequests.push({
+      caaCasesFilterType: url.searchParams.get('caaCasesFilterType'),
+      caaCasesPageType: url.searchParams.get('caaCasesPageType'),
+      method: route.request().method()
+    });
+
+    await fulfillJson(route, assignedCaseTypesResponse);
+  });
+
+  await page.route('**/api/caaCases**', async (route) => {
+    const url = routeUrl(route.request().url());
+    const caseTypeId = url.searchParams.get('caseTypeId') ?? asylumCaseType;
+
+    routeState.caseListRequests.push({
+      caaCasesFilterType: url.searchParams.get('caaCasesFilterType'),
+      caaCasesPageType: url.searchParams.get('caaCasesPageType'),
+      caseTypeId,
+      method: route.request().method(),
+      pageNo: url.searchParams.get('pageNo'),
+      pageSize: url.searchParams.get('pageSize')
+    });
+
+    await fulfillJson(route, buildAssignedCasesResponse(caseTypeId));
   });
 
   return routeState;

--- a/playwright_tests_new/integration/mocks/caseSharing.mock.ts
+++ b/playwright_tests_new/integration/mocks/caseSharing.mock.ts
@@ -102,7 +102,27 @@ export const manageOrgUsersWithoutRolesResponse = {
 };
 
 export const asylumCaseType = 'Asylum';
+export const immigrationCaseType = 'Immigration';
 export const unassignedCaseIds = ['1234567812345671', '1234567812345672'];
+export const assignedCaseIds = ['1234567812345671', '1234567812345672'];
+
+export const assignedAsylumCase = {
+  caseReference: assignedCaseIds[0],
+  caseNumber: '6042070/2023',
+  claimant: 'Grayson Becker',
+  respondent: 'Mrs Test Auto',
+  state: 'Accepted',
+  caseType: asylumCaseType
+};
+
+export const assignedImmigrationCase = {
+  caseReference: assignedCaseIds[1],
+  caseNumber: '6042071/2023',
+  claimant: 'Grayson Becker',
+  respondent: 'Mrs Test Auto',
+  state: 'Accepted',
+  caseType: immigrationCaseType
+};
 
 export const unassignedCaseRows = unassignedCaseIds.map((caseId) => ({
   '[CASE_REFERENCE]': caseId,
@@ -110,6 +130,29 @@ export const unassignedCaseRows = unassignedCaseIds.map((caseId) => ({
   caseType: asylumCaseType,
   case_title: `Asylum appeal ${caseId.slice(-4)}`
 }));
+
+export const assignedCaseRows = [assignedAsylumCase, assignedImmigrationCase].map((assignedCase) => ({
+  '[CASE_REFERENCE]': assignedCase.caseReference,
+  ethosCaseReference: assignedCase.caseNumber,
+  claimant: assignedCase.claimant,
+  respondent: assignedCase.respondent,
+  '[STATE]': assignedCase.state,
+  case_id: assignedCase.caseReference,
+  caseType: assignedCase.caseType
+}));
+
+export const assignedCaseTypesResponse = {
+  case_types_results: [
+    {
+      case_type_id: asylumCaseType,
+      total: assignedCaseRows.filter((assignedCase) => assignedCase.caseType === asylumCaseType).length
+    },
+    {
+      case_type_id: immigrationCaseType,
+      total: assignedCaseRows.filter((assignedCase) => assignedCase.caseType === immigrationCaseType).length
+    }
+  ]
+};
 
 export const unassignedCaseTypesResponse = {
   case_types_results: [
@@ -136,6 +179,38 @@ export const unassignedCasesResponse = {
   ],
   data: unassignedCaseRows
 };
+
+export const buildAssignedCasesResponse = (caseTypeId: string) => ({
+  idField: '[CASE_REFERENCE]',
+  columnConfigs: [
+    {
+      header: 'Case Reference',
+      key: '[CASE_REFERENCE]',
+      type: 'TEXT'
+    },
+    {
+      header: 'Case Number',
+      key: 'ethosCaseReference',
+      type: 'TEXT'
+    },
+    {
+      header: 'Claimant',
+      key: 'claimant',
+      type: 'TEXT'
+    },
+    {
+      header: 'Respondent',
+      key: 'respondent',
+      type: 'TEXT'
+    },
+    {
+      header: 'State',
+      key: '[STATE]',
+      type: 'FixedList'
+    }
+  ],
+  data: assignedCaseRows.filter((assignedCase) => assignedCase.caseType === caseTypeId)
+});
 
 export const buildSharedCases = (caseIds: string[]): CaseSharingSharedCase[] =>
   caseIds.map((caseId) => {

--- a/playwright_tests_new/integration/page-objects/assigned-cases.po.ts
+++ b/playwright_tests_new/integration/page-objects/assigned-cases.po.ts
@@ -1,0 +1,45 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class AssignedCasesPage {
+  public readonly assignedCasesHeading: Locator;
+  public readonly caseList: Locator;
+  public readonly manageCaseSharingButton: Locator;
+
+  constructor(private readonly page: Page) {
+    this.assignedCasesHeading = this.page.getByRole('heading', { name: 'Assigned Cases' });
+    this.caseList = this.page.locator('ccd-case-list');
+    this.manageCaseSharingButton = this.page.locator('#btn-share-assigned-case-button');
+  }
+
+  public async gotoAssignedCases(): Promise<void> {
+    await this.page.goto('/assigned-cases');
+  }
+
+  public filterButton(name: string): Locator {
+    return this.page.getByRole('button', { name, exact: true });
+  }
+
+  public caseTypeTab(caseType: string): Locator {
+    return this.page.getByRole('tab', { name: caseType, exact: true });
+  }
+
+  public caseCheckbox(caseId: string): Locator {
+    return this.page.locator(`#select-${caseId}`);
+  }
+
+  public async showAssignedCasesFilter(): Promise<void> {
+    await this.filterButton('Show assigned cases filter').click();
+  }
+
+  public async hideAssignedCasesFilter(): Promise<void> {
+    await this.filterButton('Hide assigned cases filter').click();
+  }
+
+  public async openCaseTypeTab(caseType: string): Promise<void> {
+    await this.caseTypeTab(caseType).click();
+  }
+
+  public async selectCase(caseId: string): Promise<void> {
+    await this.caseCheckbox(caseId).check();
+  }
+}

--- a/playwright_tests_new/integration/test/case-sharing/assignedCases.positive.spec.ts
+++ b/playwright_tests_new/integration/test/case-sharing/assignedCases.positive.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '../../fixtures';
+import { setupAssignedCaseRoutes } from '../../helpers';
+import {
+  assignedAsylumCase,
+  assignedImmigrationCase,
+  asylumCaseType,
+  immigrationCaseType,
+  manageOrgIntegrationOrganisationName
+} from '../../mocks/caseSharing.mock';
+import { AssignedCasesPage } from '../../page-objects/assigned-cases.po';
+
+test.describe('Assigned cases', { tag: ['@integration', '@integration-assigned-cases'] }, () => {
+  test('validates assigned case filters, tabs and case-sharing selection state', async ({
+    manageOrgIntegrationPage: page
+  }) => {
+    const routeState = await setupAssignedCaseRoutes(page);
+    const assignedCasesPage = new AssignedCasesPage(page);
+
+    await test.step('Load assigned cases from mocked integration APIs', async () => {
+      await assignedCasesPage.gotoAssignedCases();
+
+      await expect(assignedCasesPage.assignedCasesHeading).toBeVisible();
+      await expect(page.getByText(manageOrgIntegrationOrganisationName)).toBeVisible();
+      await expect(assignedCasesPage.filterButton('Show assigned cases filter')).toBeVisible();
+      await expect(assignedCasesPage.filterButton('Hide assigned cases filter')).toBeHidden();
+      await expect(assignedCasesPage.caseTypeTab(asylumCaseType)).toBeVisible();
+      await expect(assignedCasesPage.caseTypeTab(immigrationCaseType)).toBeVisible();
+      await expect(page.getByText('Showing 1 to 1 of 1 Asylum cases')).toBeVisible();
+      await expect(assignedCasesPage.manageCaseSharingButton).toBeDisabled();
+
+      await expect.poll(() => routeState.caseTypesRequests.length).toBeGreaterThan(0);
+      await expect(routeState.caseTypesRequests[0]).toEqual({
+        caaCasesFilterType: 'all-assignees',
+        caaCasesPageType: 'assigned-cases',
+        method: 'POST'
+      });
+      await expect.poll(() => routeState.caseListRequests.length).toBeGreaterThan(0);
+      expect(routeState.caseListRequests[0]).toEqual({
+        caaCasesFilterType: 'all-assignees',
+        caaCasesPageType: 'assigned-cases',
+        caseTypeId: asylumCaseType,
+        method: 'POST',
+        pageNo: '1',
+        pageSize: '25'
+      });
+    });
+
+    await test.step('Toggle assigned-cases filters using the visible controls', async () => {
+      await assignedCasesPage.showAssignedCasesFilter();
+
+      await expect(assignedCasesPage.filterButton('Hide assigned cases filter')).toBeVisible();
+      await expect(assignedCasesPage.filterButton('Show assigned cases filter')).toBeHidden();
+
+      await assignedCasesPage.hideAssignedCasesFilter();
+
+      await expect(assignedCasesPage.filterButton('Show assigned cases filter')).toBeVisible();
+      await expect(assignedCasesPage.filterButton('Hide assigned cases filter')).toBeHidden();
+    });
+
+    await test.step('Render assigned case data for each case-type tab', async () => {
+      await expect(assignedCasesPage.caseList).toContainText(assignedAsylumCase.caseReference);
+      await expect(assignedCasesPage.caseList).toContainText(assignedAsylumCase.caseNumber);
+      await expect(assignedCasesPage.caseList).toContainText(assignedAsylumCase.claimant);
+
+      await assignedCasesPage.openCaseTypeTab(immigrationCaseType);
+
+      await expect(page.getByText('Showing 1 to 1 of 1 Immigration cases')).toBeVisible();
+      await expect(assignedCasesPage.caseList).toContainText(assignedImmigrationCase.caseReference);
+      await expect(assignedCasesPage.caseList).toContainText(assignedImmigrationCase.caseNumber);
+      expect(routeState.caseListRequests).toEqual(
+        expect.arrayContaining([
+          {
+            caaCasesFilterType: 'all-assignees',
+            caaCasesPageType: 'assigned-cases',
+            caseTypeId: immigrationCaseType,
+            method: 'POST',
+            pageNo: '1',
+            pageSize: '25'
+          }
+        ])
+      );
+    });
+
+    await test.step('Enable Manage case sharing only after selecting an assigned case', async () => {
+      await assignedCasesPage.openCaseTypeTab(asylumCaseType);
+      await expect(assignedCasesPage.manageCaseSharingButton).toBeDisabled();
+
+      await assignedCasesPage.selectCase(assignedAsylumCase.caseReference);
+
+      await expect(assignedCasesPage.manageCaseSharingButton).toBeEnabled();
+    });
+  });
+});


### PR DESCRIPTION
## Jira

[EXUI-4358](https://tools.hmcts.net/jira/browse/EXUI-4358)

## What changed

Adds Playwright integration parity for the active assigned-cases legacy ngIntegration coverage.

- Adds assigned case-type and case-list mocks for Asylum and Immigration.
- Captures assigned-cases API request contracts for `caaCaseTypes` and `caaCases`.
- Adds an assigned-cases page object for route navigation and user interactions only.
- Adds a Playwright integration spec covering:
  - assigned-cases page load and organisation context
  - Show/Hide assigned-cases filter toggle
  - Asylum and Immigration case-type tabs
  - rendered case reference, case number, and claimant values
  - Manage case sharing disabled/enabled state before and after selecting a case
  - expected request parameters sent by the UI

## Added value to the test pack

This moves the active `assignedCase.feature` ngIntegration intent into the new Playwright integration framework and gives us direct evidence for another chunk of Codecept retirement.

The new test is stronger than the legacy coverage because it validates both sides of the contract:

- the user-visible assigned-cases behaviour, including real case values rather than only page labels
- the mocked API request shape, so regressions in `caaCasesPageType`, filter type, case type, page number, or page size are caught

It also follows the Manage Org Playwright standards we have been converging on:

- assertions stay in the spec
- page object is interactions-only
- no `_helpers` folder
- mocked data uses safe `example.com` addresses
- no forced clicks, XPath, `waitForTimeout`, DOM `evaluate`, or synthetic events

## Codecept retirement impact

This PR does not remove legacy Codecept coverage. It creates replacement evidence for the active assigned-cases ngIntegration scenarios first. Codecept removal should happen only after the mapped replacement coverage is merged and the relevant retirement ticket is ready.

## Validation

- `yarn lint:playwright:integration` - passed
- `git diff --check` - passed
- `yarn test:playwright:integration --grep @integration-assigned-cases` - passed, 1 test
- `yarn test:playwright:integration` - passed, 3 tests
- `yarn lint` - passed
- `yarn test:playwright:integration --grep @integration-assigned-cases --repeat-each 3` - passed, 3/3

## AI assistance

AI assistance used for implementation support; changes require normal human review before merge.
