### PR TITLE
EXUI-4623: Harden Playwright case-list integration coverage

### DIFF
--- a/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
@@ -4,7 +4,9 @@ import type {
   CaseSharingSharedCase
 } from '../mocks/caseSharing.mock';
 import {
+  assignedCaseTypesResponse,
   buildCaseAssignmentSuccessResponse,
+  buildAssignedCasesResponse,
   buildSharedCases,
   petSolicitorTwo,
   unassignedCasesResponse,
@@ -30,6 +32,11 @@ export interface UnassignedCaseShareRouteState {
   caseTypesRequests: CaseTypesRequest[];
   loadedShareCaseIds: string[][];
   submittedAssignments: CaseAssignmentsRequest[];
+}
+
+export interface AssignedCaseRouteState {
+  caseListRequests: CaseListRequest[];
+  caseTypesRequests: CaseTypesRequest[];
 }
 
 const routeUrl = (requestUrl: string): URL => new URL(requestUrl);
@@ -95,6 +102,48 @@ export const setupUnassignedCaseShareRoutes = async (
     routeState.assignmentResponses.push(responseBody);
 
     await fulfillJson(route, responseBody);
+  });
+
+  return routeState;
+};
+
+export const setupAssignedCaseRoutes = async (page: Page): Promise<AssignedCaseRouteState> => {
+  const routeState: AssignedCaseRouteState = {
+    caseListRequests: [],
+    caseTypesRequests: []
+  };
+
+  await page.route('**/api/caaCaseTypes**', async (route) => {
+    const url = routeUrl(route.request().url());
+
+    routeState.caseTypesRequests.push({
+      caaCasesFilterType: url.searchParams.get('caaCasesFilterType'),
+      caaCasesPageType: url.searchParams.get('caaCasesPageType'),
+      method: route.request().method()
+    });
+
+    await fulfillJson(route, assignedCaseTypesResponse);
+  });
+
+  await page.route('**/api/caaCases**', async (route) => {
+    const url = routeUrl(route.request().url());
+    const caseTypeId = url.searchParams.get('caseTypeId');
+
+    routeState.caseListRequests.push({
+      caaCasesFilterType: url.searchParams.get('caaCasesFilterType'),
+      caaCasesPageType: url.searchParams.get('caaCasesPageType'),
+      caseTypeId,
+      method: route.request().method(),
+      pageNo: url.searchParams.get('pageNo'),
+      pageSize: url.searchParams.get('pageSize')
+    });
+
+    if (!caseTypeId) {
+      await fulfillJson(route, { error: 'Missing caseTypeId query parameter' }, 400);
+      return;
+    }
+
+    await fulfillJson(route, buildAssignedCasesResponse(caseTypeId));
   });
 
   return routeState;

--- a/playwright_tests_new/integration/mocks/caseSharing.mock.ts
+++ b/playwright_tests_new/integration/mocks/caseSharing.mock.ts
@@ -102,7 +102,27 @@ export const manageOrgUsersWithoutRolesResponse = {
 };
 
 export const asylumCaseType = 'Asylum';
+export const immigrationCaseType = 'Immigration';
 export const unassignedCaseIds = ['1234567812345671', '1234567812345672'];
+export const assignedCaseIds = ['1234567812345671', '1234567812345672'];
+
+export const assignedAsylumCase = {
+  caseReference: assignedCaseIds[0],
+  caseNumber: '6042070/2023',
+  claimant: 'Grayson Becker',
+  respondent: 'Mrs Test Auto',
+  state: 'Accepted',
+  caseType: asylumCaseType
+};
+
+export const assignedImmigrationCase = {
+  caseReference: assignedCaseIds[1],
+  caseNumber: '6042071/2023',
+  claimant: 'Grayson Becker',
+  respondent: 'Mrs Test Auto',
+  state: 'Accepted',
+  caseType: immigrationCaseType
+};
 
 export const unassignedCaseRows = unassignedCaseIds.map((caseId) => ({
   '[CASE_REFERENCE]': caseId,
@@ -110,6 +130,29 @@ export const unassignedCaseRows = unassignedCaseIds.map((caseId) => ({
   caseType: asylumCaseType,
   case_title: `Asylum appeal ${caseId.slice(-4)}`
 }));
+
+export const assignedCaseRows = [assignedAsylumCase, assignedImmigrationCase].map((assignedCase) => ({
+  '[CASE_REFERENCE]': assignedCase.caseReference,
+  ethosCaseReference: assignedCase.caseNumber,
+  claimant: assignedCase.claimant,
+  respondent: assignedCase.respondent,
+  '[STATE]': assignedCase.state,
+  case_id: assignedCase.caseReference,
+  caseType: assignedCase.caseType
+}));
+
+export const assignedCaseTypesResponse = {
+  case_types_results: [
+    {
+      case_type_id: asylumCaseType,
+      total: assignedCaseRows.filter((assignedCase) => assignedCase.caseType === asylumCaseType).length
+    },
+    {
+      case_type_id: immigrationCaseType,
+      total: assignedCaseRows.filter((assignedCase) => assignedCase.caseType === immigrationCaseType).length
+    }
+  ]
+};
 
 export const unassignedCaseTypesResponse = {
   case_types_results: [
@@ -136,6 +179,38 @@ export const unassignedCasesResponse = {
   ],
   data: unassignedCaseRows
 };
+
+export const buildAssignedCasesResponse = (caseTypeId: string) => ({
+  idField: '[CASE_REFERENCE]',
+  columnConfigs: [
+    {
+      header: 'Case Reference',
+      key: '[CASE_REFERENCE]',
+      type: 'TEXT'
+    },
+    {
+      header: 'Case Number',
+      key: 'ethosCaseReference',
+      type: 'TEXT'
+    },
+    {
+      header: 'Claimant',
+      key: 'claimant',
+      type: 'TEXT'
+    },
+    {
+      header: 'Respondent',
+      key: 'respondent',
+      type: 'TEXT'
+    },
+    {
+      header: 'State',
+      key: '[STATE]',
+      type: 'FixedList'
+    }
+  ],
+  data: assignedCaseRows.filter((assignedCase) => assignedCase.caseType === caseTypeId)
+});
 
 export const buildSharedCases = (caseIds: string[]): CaseSharingSharedCase[] =>
   caseIds.map((caseId) => {

--- a/playwright_tests_new/integration/page-objects/assigned-cases.po.ts
+++ b/playwright_tests_new/integration/page-objects/assigned-cases.po.ts
@@ -1,0 +1,45 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class AssignedCasesPage {
+  public readonly assignedCasesHeading: Locator;
+  public readonly caseList: Locator;
+  public readonly manageCaseSharingButton: Locator;
+
+  constructor(private readonly page: Page) {
+    this.assignedCasesHeading = this.page.getByRole('heading', { name: 'Assigned Cases' });
+    this.caseList = this.page.locator('ccd-case-list');
+    this.manageCaseSharingButton = this.page.locator('#btn-share-assigned-case-button');
+  }
+
+  public async gotoAssignedCases(): Promise<void> {
+    await this.page.goto('/assigned-cases');
+  }
+
+  public filterButton(name: string): Locator {
+    return this.page.getByRole('button', { name, exact: true });
+  }
+
+  public caseTypeTab(caseType: string): Locator {
+    return this.page.getByRole('tab', { name: caseType, exact: true });
+  }
+
+  public caseCheckbox(caseId: string): Locator {
+    return this.page.locator(`#select-${caseId}`);
+  }
+
+  public async showAssignedCasesFilter(): Promise<void> {
+    await this.filterButton('Show assigned cases filter').click();
+  }
+
+  public async hideAssignedCasesFilter(): Promise<void> {
+    await this.filterButton('Hide assigned cases filter').click();
+  }
+
+  public async openCaseTypeTab(caseType: string): Promise<void> {
+    await this.caseTypeTab(caseType).click();
+  }
+
+  public async selectCase(caseId: string): Promise<void> {
+    await this.caseCheckbox(caseId).check();
+  }
+}

--- a/playwright_tests_new/integration/test/case-sharing/assignedCases.positive.spec.ts
+++ b/playwright_tests_new/integration/test/case-sharing/assignedCases.positive.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '../../fixtures';
+import { setupAssignedCaseRoutes } from '../../helpers';
+import {
+  assignedAsylumCase,
+  assignedImmigrationCase,
+  asylumCaseType,
+  immigrationCaseType,
+  manageOrgIntegrationOrganisationName
+} from '../../mocks/caseSharing.mock';
+import { AssignedCasesPage } from '../../page-objects/assigned-cases.po';
+
+test.describe('Assigned cases', { tag: ['@integration', '@integration-assigned-cases'] }, () => {
+  test('validates assigned case filters, tabs and case-sharing selection state', async ({
+    manageOrgIntegrationPage: page
+  }) => {
+    const routeState = await setupAssignedCaseRoutes(page);
+    const assignedCasesPage = new AssignedCasesPage(page);
+
+    await test.step('Load assigned cases from mocked integration APIs', async () => {
+      await assignedCasesPage.gotoAssignedCases();
+
+      await expect(assignedCasesPage.assignedCasesHeading).toBeVisible();
+      await expect(page.getByText(manageOrgIntegrationOrganisationName)).toBeVisible();
+      await expect(assignedCasesPage.filterButton('Show assigned cases filter')).toBeVisible();
+      await expect(assignedCasesPage.filterButton('Hide assigned cases filter')).toBeHidden();
+      await expect(assignedCasesPage.caseTypeTab(asylumCaseType)).toBeVisible();
+      await expect(assignedCasesPage.caseTypeTab(immigrationCaseType)).toBeVisible();
+      await expect(page.getByText('Showing 1 to 1 of 1 Asylum cases')).toBeVisible();
+      await expect(assignedCasesPage.manageCaseSharingButton).toBeDisabled();
+
+      await expect.poll(() => routeState.caseTypesRequests.length).toBeGreaterThan(0);
+      await expect(routeState.caseTypesRequests[0]).toEqual({
+        caaCasesFilterType: 'all-assignees',
+        caaCasesPageType: 'assigned-cases',
+        method: 'POST'
+      });
+      await expect.poll(() => routeState.caseListRequests.length).toBeGreaterThan(0);
+      expect(routeState.caseListRequests[0]).toEqual({
+        caaCasesFilterType: 'all-assignees',
+        caaCasesPageType: 'assigned-cases',
+        caseTypeId: asylumCaseType,
+        method: 'POST',
+        pageNo: '1',
+        pageSize: '25'
+      });
+    });
+
+    await test.step('Toggle assigned-cases filters using the visible controls', async () => {
+      await assignedCasesPage.showAssignedCasesFilter();
+
+      await expect(assignedCasesPage.filterButton('Hide assigned cases filter')).toBeVisible();
+      await expect(assignedCasesPage.filterButton('Show assigned cases filter')).toBeHidden();
+
+      await assignedCasesPage.hideAssignedCasesFilter();
+
+      await expect(assignedCasesPage.filterButton('Show assigned cases filter')).toBeVisible();
+      await expect(assignedCasesPage.filterButton('Hide assigned cases filter')).toBeHidden();
+    });
+
+    await test.step('Render assigned case data for each case-type tab', async () => {
+      await expect(assignedCasesPage.caseList).toContainText(assignedAsylumCase.caseReference);
+      await expect(assignedCasesPage.caseList).toContainText(assignedAsylumCase.caseNumber);
+      await expect(assignedCasesPage.caseList).toContainText(assignedAsylumCase.claimant);
+
+      await assignedCasesPage.openCaseTypeTab(immigrationCaseType);
+
+      await expect(page.getByText('Showing 1 to 1 of 1 Immigration cases')).toBeVisible();
+      await expect(assignedCasesPage.caseList).toContainText(assignedImmigrationCase.caseReference);
+      await expect(assignedCasesPage.caseList).toContainText(assignedImmigrationCase.caseNumber);
+      expect(routeState.caseListRequests).toEqual(
+        expect.arrayContaining([
+          {
+            caaCasesFilterType: 'all-assignees',
+            caaCasesPageType: 'assigned-cases',
+            caseTypeId: immigrationCaseType,
+            method: 'POST',
+            pageNo: '1',
+            pageSize: '25'
+          }
+        ])
+      );
+    });
+
+    await test.step('Enable Manage case sharing only after selecting an assigned case', async () => {
+      await assignedCasesPage.openCaseTypeTab(asylumCaseType);
+      await expect(assignedCasesPage.manageCaseSharingButton).toBeDisabled();
+
+      await assignedCasesPage.selectCase(assignedAsylumCase.caseReference);
+
+      await expect(assignedCasesPage.manageCaseSharingButton).toBeEnabled();
+    });
+  });
+});


### PR DESCRIPTION
## Jira

[EXUI-4623](https://tools.hmcts.net/jira/browse/EXUI-4623)

## Summary

Adds the next Playwright integration hardening slice for Manage Org case-list mocked journeys now that assigned-cases parity has landed on master via PR #1551.

This PR keeps the work focused on gaps that still add value:

- tightens assigned and unassigned case-list mock routes so missing `caseTypeId` is treated as a broken request contract instead of being hidden by fallback mock data
- adds the legacy unassigned-cases filter validation intent to the Playwright integration flow
- asserts the GOV.UK problem summary and field-level error for an empty/invalid unassigned case-reference filter before continuing into the existing share-case journey
- keeps page objects to locators and user interactions, with all behavioural assertions remaining in the spec

## Added value to the test pack

- Prevents false confidence in mocked integration coverage by failing fast when the app stops sending the expected case-list query parameters.
- Brings another Codecept ngIntegration behaviour into Playwright: unassigned case-list filter show/hide plus invalid case-reference validation.
- Strengthens the case-list retirement path without reintroducing live AAT data dependency.
- Keeps the PR small and reviewable after #1551 merged the assigned-cases base coverage.

## Validation

- `yarn lint`
- `git diff --check`
- `PLAYWRIGHT_SKIP_INSTALL=true PLAYWRIGHT_REPORTERS=list yarn test:playwright:integration -- test/case-sharing/unassignedCases.positive.spec.ts test/case-sharing/assignedCases.positive.spec.ts`

Result: 2 Playwright integration tests passed locally.
