### PR TITLE
EXUI-4359: Add remaining unassigned-cases integration parity

### DIFF
--- a/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
@@ -5,12 +5,11 @@ import type {
 } from '../mocks/caseSharing.mock';
 import {
   assignedCaseTypesResponse,
-  asylumCaseType,
   buildCaseAssignmentSuccessResponse,
   buildAssignedCasesResponse,
+  buildUnassignedCasesResponse,
   buildSharedCases,
   petSolicitorTwo,
-  unassignedCasesResponse,
   unassignedCaseTypesResponse
 } from '../mocks/caseSharing.mock';
 import { fulfillJson } from './manageOrgBaseRoutes.helper';
@@ -67,17 +66,23 @@ export const setupUnassignedCaseShareRoutes = async (
 
   await page.route('**/api/caaCases**', async (route) => {
     const url = routeUrl(route.request().url());
+    const caseTypeId = url.searchParams.get('caseTypeId');
 
     routeState.caseListRequests.push({
       caaCasesFilterType: url.searchParams.get('caaCasesFilterType'),
       caaCasesPageType: url.searchParams.get('caaCasesPageType'),
-      caseTypeId: url.searchParams.get('caseTypeId'),
+      caseTypeId,
       method: route.request().method(),
       pageNo: url.searchParams.get('pageNo'),
       pageSize: url.searchParams.get('pageSize')
     });
 
-    await fulfillJson(route, unassignedCasesResponse);
+    if (!caseTypeId) {
+      await fulfillJson(route, { error: 'Missing caseTypeId query parameter' }, 400);
+      return;
+    }
+
+    await fulfillJson(route, buildUnassignedCasesResponse(caseTypeId));
   });
 
   await page.route('**/api/caseshare/cases**', async (route) => {
@@ -128,7 +133,7 @@ export const setupAssignedCaseRoutes = async (page: Page): Promise<AssignedCaseR
 
   await page.route('**/api/caaCases**', async (route) => {
     const url = routeUrl(route.request().url());
-    const caseTypeId = url.searchParams.get('caseTypeId') ?? asylumCaseType;
+    const caseTypeId = url.searchParams.get('caseTypeId');
 
     routeState.caseListRequests.push({
       caaCasesFilterType: url.searchParams.get('caaCasesFilterType'),
@@ -138,6 +143,11 @@ export const setupAssignedCaseRoutes = async (page: Page): Promise<AssignedCaseR
       pageNo: url.searchParams.get('pageNo'),
       pageSize: url.searchParams.get('pageSize')
     });
+
+    if (!caseTypeId) {
+      await fulfillJson(route, { error: 'Missing caseTypeId query parameter' }, 400);
+      return;
+    }
 
     await fulfillJson(route, buildAssignedCasesResponse(caseTypeId));
   });

--- a/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
@@ -67,7 +67,7 @@ export const setupUnassignedCaseShareRoutes = async (
 
   await page.route('**/api/caaCases**', async (route) => {
     const url = routeUrl(route.request().url());
-    const caseTypeId = url.searchParams.get('caseTypeId') ?? asylumCaseType;
+    const caseTypeId = url.searchParams.get('caseTypeId');
 
     routeState.caseListRequests.push({
       caaCasesFilterType: url.searchParams.get('caaCasesFilterType'),
@@ -134,7 +134,7 @@ export const setupAssignedCaseRoutes = async (page: Page): Promise<AssignedCaseR
 
   await page.route('**/api/caaCases**', async (route) => {
     const url = routeUrl(route.request().url());
-    const caseTypeId = url.searchParams.get('caseTypeId');
+    const caseTypeId = url.searchParams.get('caseTypeId') ?? asylumCaseType;
 
     routeState.caseListRequests.push({
       caaCasesFilterType: url.searchParams.get('caaCasesFilterType'),

--- a/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/caseSharingMockRoutes.helper.ts
@@ -5,6 +5,7 @@ import type {
 } from '../mocks/caseSharing.mock';
 import {
   assignedCaseTypesResponse,
+  asylumCaseType,
   buildCaseAssignmentSuccessResponse,
   buildAssignedCasesResponse,
   buildUnassignedCasesResponse,
@@ -66,7 +67,7 @@ export const setupUnassignedCaseShareRoutes = async (
 
   await page.route('**/api/caaCases**', async (route) => {
     const url = routeUrl(route.request().url());
-    const caseTypeId = url.searchParams.get('caseTypeId');
+    const caseTypeId = url.searchParams.get('caseTypeId') ?? asylumCaseType;
 
     routeState.caseListRequests.push({
       caaCasesFilterType: url.searchParams.get('caaCasesFilterType'),
@@ -143,11 +144,6 @@ export const setupAssignedCaseRoutes = async (page: Page): Promise<AssignedCaseR
       pageNo: url.searchParams.get('pageNo'),
       pageSize: url.searchParams.get('pageSize')
     });
-
-    if (!caseTypeId) {
-      await fulfillJson(route, { error: 'Missing caseTypeId query parameter' }, 400);
-      return;
-    }
 
     await fulfillJson(route, buildAssignedCasesResponse(caseTypeId));
   });

--- a/playwright_tests_new/integration/mocks/caseSharing.mock.ts
+++ b/playwright_tests_new/integration/mocks/caseSharing.mock.ts
@@ -103,8 +103,8 @@ export const manageOrgUsersWithoutRolesResponse = {
 
 export const asylumCaseType = 'Asylum';
 export const immigrationCaseType = 'Immigration';
-export const unassignedCaseIds = ['1234567812345671', '1234567812345672'];
-export const unassignedImmigrationCaseId = '1234567812345673';
+export const unassignedCaseIds = ['1234567812345681', '1234567812345682'];
+export const unassignedImmigrationCaseId = '1234567812345683';
 export const assignedCaseIds = ['1234567812345671', '1234567812345672'];
 
 export const assignedAsylumCase = {
@@ -132,7 +132,7 @@ export const unassignedAsylumCase = {
   respondent: 'Secretary of State',
   state: 'Case created',
   caseType: asylumCaseType,
-  caseTitle: 'Asylum appeal 5671'
+  caseTitle: 'Asylum appeal 5681'
 };
 
 export const unassignedSecondAsylumCase = {
@@ -142,7 +142,7 @@ export const unassignedSecondAsylumCase = {
   respondent: 'Secretary of State',
   state: 'Case created',
   caseType: asylumCaseType,
-  caseTitle: 'Asylum appeal 5672'
+  caseTitle: 'Asylum appeal 5682'
 };
 
 export const unassignedImmigrationCase = {
@@ -152,7 +152,7 @@ export const unassignedImmigrationCase = {
   respondent: 'Secretary of State',
   state: 'Case created',
   caseType: immigrationCaseType,
-  caseTitle: 'Immigration appeal 5673'
+  caseTitle: 'Immigration appeal 5683'
 };
 
 export const unassignedCaseRows = [

--- a/playwright_tests_new/integration/mocks/caseSharing.mock.ts
+++ b/playwright_tests_new/integration/mocks/caseSharing.mock.ts
@@ -104,6 +104,7 @@ export const manageOrgUsersWithoutRolesResponse = {
 export const asylumCaseType = 'Asylum';
 export const immigrationCaseType = 'Immigration';
 export const unassignedCaseIds = ['1234567812345671', '1234567812345672'];
+export const unassignedImmigrationCaseId = '1234567812345673';
 export const assignedCaseIds = ['1234567812345671', '1234567812345672'];
 
 export const assignedAsylumCase = {
@@ -124,11 +125,49 @@ export const assignedImmigrationCase = {
   caseType: immigrationCaseType
 };
 
-export const unassignedCaseRows = unassignedCaseIds.map((caseId) => ({
-  '[CASE_REFERENCE]': caseId,
-  case_id: caseId,
+export const unassignedAsylumCase = {
+  caseReference: unassignedCaseIds[0],
+  caseNumber: '6042072/2023',
+  claimant: 'Riley Harper',
+  respondent: 'Secretary of State',
+  state: 'Case created',
   caseType: asylumCaseType,
-  case_title: `Asylum appeal ${caseId.slice(-4)}`
+  caseTitle: 'Asylum appeal 5671'
+};
+
+export const unassignedSecondAsylumCase = {
+  caseReference: unassignedCaseIds[1],
+  caseNumber: '6042073/2023',
+  claimant: 'Morgan Drew',
+  respondent: 'Secretary of State',
+  state: 'Case created',
+  caseType: asylumCaseType,
+  caseTitle: 'Asylum appeal 5672'
+};
+
+export const unassignedImmigrationCase = {
+  caseReference: unassignedImmigrationCaseId,
+  caseNumber: '6042074/2023',
+  claimant: 'Taylor Quinn',
+  respondent: 'Secretary of State',
+  state: 'Case created',
+  caseType: immigrationCaseType,
+  caseTitle: 'Immigration appeal 5673'
+};
+
+export const unassignedCaseRows = [
+  unassignedAsylumCase,
+  unassignedSecondAsylumCase,
+  unassignedImmigrationCase
+].map((unassignedCase) => ({
+  '[CASE_REFERENCE]': unassignedCase.caseReference,
+  ethosCaseReference: unassignedCase.caseNumber,
+  claimant: unassignedCase.claimant,
+  respondent: unassignedCase.respondent,
+  '[STATE]': unassignedCase.state,
+  case_id: unassignedCase.caseReference,
+  caseType: unassignedCase.caseType,
+  case_title: unassignedCase.caseTitle
 }));
 
 export const assignedCaseRows = [assignedAsylumCase, assignedImmigrationCase].map((assignedCase) => ({
@@ -158,27 +197,46 @@ export const unassignedCaseTypesResponse = {
   case_types_results: [
     {
       case_type_id: asylumCaseType,
-      total: unassignedCaseIds.length
+      total: unassignedCaseRows.filter((unassignedCase) => unassignedCase.caseType === asylumCaseType).length
+    },
+    {
+      case_type_id: immigrationCaseType,
+      total: unassignedCaseRows.filter((unassignedCase) => unassignedCase.caseType === immigrationCaseType).length
     }
   ]
 };
 
-export const unassignedCasesResponse = {
+export const buildUnassignedCasesResponse = (caseTypeId: string) => ({
   idField: '[CASE_REFERENCE]',
   columnConfigs: [
     {
-      header: 'Case reference',
+      header: 'Case Reference',
       key: '[CASE_REFERENCE]',
-      type: 'text'
+      type: 'TEXT'
     },
     {
-      header: 'Case name',
-      key: 'case_title',
-      type: 'text'
+      header: 'Case Number',
+      key: 'ethosCaseReference',
+      type: 'TEXT'
+    },
+    {
+      header: 'Claimant',
+      key: 'claimant',
+      type: 'TEXT'
+    },
+    {
+      header: 'Respondent',
+      key: 'respondent',
+      type: 'TEXT'
+    },
+    {
+      header: 'State',
+      key: '[STATE]',
+      type: 'FixedList'
     }
   ],
-  data: unassignedCaseRows
-};
+  data: unassignedCaseRows.filter((unassignedCase) => unassignedCase.caseType === caseTypeId)
+});
 
 export const buildAssignedCasesResponse = (caseTypeId: string) => ({
   idField: '[CASE_REFERENCE]',

--- a/playwright_tests_new/integration/page-objects/case-sharing.po.ts
+++ b/playwright_tests_new/integration/page-objects/case-sharing.po.ts
@@ -4,6 +4,9 @@ const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\
 
 export class UnassignedCaseSharingPage {
   public readonly addUserButton: Locator;
+  public readonly applyFilterButton: Locator;
+  public readonly caseList: Locator;
+  public readonly caseReferenceError: Locator;
   public readonly confirmButton: Locator;
   public readonly continueButton: Locator;
   public readonly recipientSearchInput: Locator;
@@ -13,6 +16,9 @@ export class UnassignedCaseSharingPage {
 
   constructor(private readonly page: Page) {
     this.addUserButton = this.page.locator('#btn-add-user');
+    this.applyFilterButton = this.page.getByRole('button', { name: 'Apply filter' });
+    this.caseList = this.page.locator('ccd-case-list');
+    this.caseReferenceError = this.page.locator('#case-reference-number-error-message');
     this.confirmButton = this.page.getByRole('button', { name: 'Confirm' });
     this.continueButton = this.page.locator('#btn-continue');
     this.recipientSearchInput = this.page.locator('#add-user-input').getByRole('combobox');
@@ -25,8 +31,12 @@ export class UnassignedCaseSharingPage {
     await this.page.goto('/unassigned-cases');
   }
 
-  public asylumTab(caseType: string): Locator {
-    return this.page.getByRole('tab', { name: caseType });
+  public filterButton(name: string): Locator {
+    return this.page.getByRole('button', { name, exact: true });
+  }
+
+  public caseTypeTab(caseType: string): Locator {
+    return this.page.getByRole('tab', { name: caseType, exact: true });
   }
 
   public caseCheckbox(caseId: string): Locator {
@@ -45,6 +55,22 @@ export class UnassignedCaseSharingPage {
     for (const caseId of caseIds) {
       await this.caseCheckbox(caseId).check();
     }
+  }
+
+  public async showUnassignedCasesFilter(): Promise<void> {
+    await this.filterButton('Show unassigned cases filter').click();
+  }
+
+  public async hideUnassignedCasesFilter(): Promise<void> {
+    await this.filterButton('Hide unassigned cases filter').click();
+  }
+
+  public async openCaseTypeTab(caseType: string): Promise<void> {
+    await this.caseTypeTab(caseType).click();
+  }
+
+  public async applyFilter(): Promise<void> {
+    await this.applyFilterButton.click();
   }
 
   public async startCaseSharing(): Promise<void> {

--- a/playwright_tests_new/integration/test/case-sharing/unassignedCases.positive.spec.ts
+++ b/playwright_tests_new/integration/test/case-sharing/unassignedCases.positive.spec.ts
@@ -32,7 +32,7 @@ test.describe('Unassigned case sharing', { tag: ['@integration', '@integration-c
       await expect(caseSharingPage.caseTypeTab(asylumCaseType)).toBeVisible();
       await expect(caseSharingPage.caseTypeTab(immigrationCaseType)).toBeVisible();
       await expect(caseSharingPage.shareCaseButton).toBeDisabled();
-      await expect(page.getByText('Showing 1 to 2 of 2 Asylum cases')).toBeVisible();
+      await expect(page.getByText('Showing 1 to 2 of 2 Asylum cases', { exact: true })).toBeVisible();
       await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.caseReference);
       await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.caseNumber);
       await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.claimant);
@@ -58,7 +58,7 @@ test.describe('Unassigned case sharing', { tag: ['@integration', '@integration-c
     await test.step('Render unassigned case data for each case-type tab', async () => {
       await caseSharingPage.openCaseTypeTab(immigrationCaseType);
 
-      await expect(page.getByText('Showing 1 to 1 of 1 Immigration cases')).toBeVisible();
+      await expect(page.getByText('Showing 1 to 1 of 1 Immigration cases', { exact: true })).toBeVisible();
       await expect(caseSharingPage.caseList).toContainText(unassignedImmigrationCase.caseReference);
       await expect(caseSharingPage.caseList).toContainText(unassignedImmigrationCase.caseNumber);
       await expect(caseSharingPage.caseList).toContainText(unassignedImmigrationCase.claimant);
@@ -76,7 +76,7 @@ test.describe('Unassigned case sharing', { tag: ['@integration', '@integration-c
       ).toBe(true);
 
       await caseSharingPage.openCaseTypeTab(asylumCaseType);
-      await expect(page.getByText('Showing 1 to 2 of 2 Asylum cases')).toBeVisible();
+      await expect(page.getByText('Showing 1 to 2 of 2 Asylum cases', { exact: true })).toBeVisible();
       await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.caseReference);
       await expect(caseSharingPage.caseList).toContainText(unassignedSecondAsylumCase.caseReference);
       await expect(caseSharingPage.caseList).not.toContainText(unassignedImmigrationCase.caseReference);

--- a/playwright_tests_new/integration/test/case-sharing/unassignedCases.positive.spec.ts
+++ b/playwright_tests_new/integration/test/case-sharing/unassignedCases.positive.spec.ts
@@ -7,7 +7,8 @@ import {
   petSolicitorTwo,
   unassignedAsylumCase,
   unassignedCaseIds,
-  unassignedImmigrationCase
+  unassignedImmigrationCase,
+  unassignedSecondAsylumCase
 } from '../../mocks/caseSharing.mock';
 import { UnassignedCaseSharingPage } from '../../page-objects/case-sharing.po';
 
@@ -35,6 +36,7 @@ test.describe('Unassigned case sharing', { tag: ['@integration', '@integration-c
       await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.caseReference);
       await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.caseNumber);
       await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.claimant);
+      await expect(caseSharingPage.caseList).toContainText(unassignedSecondAsylumCase.caseReference);
 
       await expect.poll(() => routeState.caseTypesRequests.length).toBeGreaterThan(0);
       await expect(routeState.caseTypesRequests[0]).toEqual({
@@ -60,6 +62,8 @@ test.describe('Unassigned case sharing', { tag: ['@integration', '@integration-c
       await expect(caseSharingPage.caseList).toContainText(unassignedImmigrationCase.caseReference);
       await expect(caseSharingPage.caseList).toContainText(unassignedImmigrationCase.caseNumber);
       await expect(caseSharingPage.caseList).toContainText(unassignedImmigrationCase.claimant);
+      await expect(caseSharingPage.caseList).not.toContainText(unassignedAsylumCase.caseReference);
+      await expect(caseSharingPage.caseList).not.toContainText(unassignedSecondAsylumCase.caseReference);
       await expect.poll(() =>
         routeState.caseListRequests.some((request) =>
           request.caaCasesFilterType === 'none' &&
@@ -73,6 +77,9 @@ test.describe('Unassigned case sharing', { tag: ['@integration', '@integration-c
 
       await caseSharingPage.openCaseTypeTab(asylumCaseType);
       await expect(page.getByText('Showing 1 to 2 of 2 Asylum cases')).toBeVisible();
+      await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.caseReference);
+      await expect(caseSharingPage.caseList).toContainText(unassignedSecondAsylumCase.caseReference);
+      await expect(caseSharingPage.caseList).not.toContainText(unassignedImmigrationCase.caseReference);
     });
 
     await test.step('Validate the unassigned case reference filter before sharing', async () => {

--- a/playwright_tests_new/integration/test/case-sharing/unassignedCases.positive.spec.ts
+++ b/playwright_tests_new/integration/test/case-sharing/unassignedCases.positive.spec.ts
@@ -2,9 +2,12 @@ import { expect, test } from '../../fixtures';
 import { setupUnassignedCaseShareRoutes } from '../../helpers';
 import {
   asylumCaseType,
+  immigrationCaseType,
   manageOrgIntegrationOrganisationName,
   petSolicitorTwo,
-  unassignedCaseIds
+  unassignedAsylumCase,
+  unassignedCaseIds,
+  unassignedImmigrationCase
 } from '../../mocks/caseSharing.mock';
 import { UnassignedCaseSharingPage } from '../../page-objects/case-sharing.po';
 
@@ -23,9 +26,15 @@ test.describe('Unassigned case sharing', { tag: ['@integration', '@integration-c
 
       await expect(caseSharingPage.unassignedCasesHeading).toBeVisible();
       await expect(page.getByText(manageOrgIntegrationOrganisationName)).toBeVisible();
-      await expect(caseSharingPage.asylumTab(asylumCaseType)).toBeVisible();
+      await expect(caseSharingPage.filterButton('Show unassigned cases filter')).toBeVisible();
+      await expect(caseSharingPage.filterButton('Hide unassigned cases filter')).toBeHidden();
+      await expect(caseSharingPage.caseTypeTab(asylumCaseType)).toBeVisible();
+      await expect(caseSharingPage.caseTypeTab(immigrationCaseType)).toBeVisible();
       await expect(caseSharingPage.shareCaseButton).toBeDisabled();
       await expect(page.getByText('Showing 1 to 2 of 2 Asylum cases')).toBeVisible();
+      await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.caseReference);
+      await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.caseNumber);
+      await expect(caseSharingPage.caseList).toContainText(unassignedAsylumCase.claimant);
 
       await expect.poll(() => routeState.caseTypesRequests.length).toBeGreaterThan(0);
       await expect(routeState.caseTypesRequests[0]).toEqual({
@@ -42,6 +51,54 @@ test.describe('Unassigned case sharing', { tag: ['@integration', '@integration-c
         pageNo: '1',
         pageSize: '25'
       });
+    });
+
+    await test.step('Render unassigned case data for each case-type tab', async () => {
+      await caseSharingPage.openCaseTypeTab(immigrationCaseType);
+
+      await expect(page.getByText('Showing 1 to 1 of 1 Immigration cases')).toBeVisible();
+      await expect(caseSharingPage.caseList).toContainText(unassignedImmigrationCase.caseReference);
+      await expect(caseSharingPage.caseList).toContainText(unassignedImmigrationCase.caseNumber);
+      await expect(caseSharingPage.caseList).toContainText(unassignedImmigrationCase.claimant);
+      await expect.poll(() =>
+        routeState.caseListRequests.some((request) =>
+          request.caaCasesFilterType === 'none' &&
+          request.caaCasesPageType === 'unassigned-cases' &&
+          request.caseTypeId === immigrationCaseType &&
+          request.method === 'POST' &&
+          request.pageNo === '1' &&
+          request.pageSize === '25'
+        )
+      ).toBe(true);
+
+      await caseSharingPage.openCaseTypeTab(asylumCaseType);
+      await expect(page.getByText('Showing 1 to 2 of 2 Asylum cases')).toBeVisible();
+    });
+
+    await test.step('Validate the unassigned case reference filter before sharing', async () => {
+      await caseSharingPage.showUnassignedCasesFilter();
+
+      await expect(caseSharingPage.filterButton('Hide unassigned cases filter')).toBeVisible();
+      await expect(caseSharingPage.filterButton('Show unassigned cases filter')).toBeHidden();
+
+      const caseTypesRequestCount = routeState.caseTypesRequests.length;
+      const caseListRequestCount = routeState.caseListRequests.length;
+
+      await caseSharingPage.applyFilter();
+
+      await expect(page.getByRole('alert', { name: 'There is a problem' })).toContainText(
+        'Enter a valid HMCTS case reference number'
+      );
+      await expect(caseSharingPage.caseReferenceError).toContainText(
+        'Enter a valid HMCTS case reference number'
+      );
+      expect(routeState.caseTypesRequests).toHaveLength(caseTypesRequestCount);
+      expect(routeState.caseListRequests).toHaveLength(caseListRequestCount);
+
+      await caseSharingPage.hideUnassignedCasesFilter();
+
+      await expect(caseSharingPage.filterButton('Show unassigned cases filter')).toBeVisible();
+      await expect(caseSharingPage.filterButton('Hide unassigned cases filter')).toBeHidden();
     });
 
     await test.step('Select two cases and open the share journey', async () => {


### PR DESCRIPTION
## What changed

Adds the remaining unassigned-cases Playwright integration parity for Manage Org case sharing.

This PR strengthens the mocked integration harness so unassigned case-list data behaves like the real case-list contract:

- unassigned case types now include both Asylum and Immigration
- unassigned mock case references are distinct from assigned mock case references
- unassigned `/api/caaCases` returns rows filtered by the requested `caseTypeId`
- missing unassigned `caseTypeId` now fails fast instead of returning broad fallback data
- the Playwright spec asserts visible case row values and absence of rows from the non-selected case-type tab
- invalid filter validation is checked without allowing an accidental API refresh
- the existing selected-case sharing journey continues to prove cancelled recipient validation and final submitted assignment payloads

## Added value

This closes a meaningful part of the legacy ngIntegration gap for unassigned cases. The test now proves the user can load unassigned cases, switch between case-type tabs, see the expected row data, validate the filter error state, and continue through the unassigned share-case journey using mocked integration APIs.

The unassigned route hardening also improves failure signal. If the UI stops sending the correct `caseTypeId`, the test fails instead of silently rendering unrelated mock data.

## Validation

- `yarn lint`
- `PLAYWRIGHT_SKIP_INSTALL=true PLAYWRIGHT_REPORTERS=list yarn test:playwright:integration -- test/case-sharing/unassignedCases.positive.spec.ts test/case-sharing/assignedCases.positive.spec.ts`
- `git diff --check`

## Notes

This PR does not retire Codecept ngIntegration by itself. It provides parity coverage needed before retirement work can safely remove or bypass the legacy unassigned-cases path.
