### PR TITLE
EXUI-4638: Harden Pact consumer async assertions

### DIFF
--- a/api/test/pact/pact-tests/aacCaseAssignment/getCases.spec.ts
+++ b/api/test/pact/pact-tests/aacCaseAssignment/getCases.spec.ts
@@ -8,7 +8,7 @@ const { somethingLike } = Matchers;
 const pactSetUp = new PactTestSetup({ provider: 'acc_manageCaseAssignment', port: 8000 });
 
 describe('Get cases from acc ', () => {
-  describe('Get cases from acc', async () => {
+  describe('Get cases from acc', () => {
     before(async () => {
       await pactSetUp.provider.setup();
       const interaction = {
@@ -35,31 +35,27 @@ describe('Get cases from acc ', () => {
         }
       };
       // @ts-ignore
-      pactSetUp.provider.addInteraction(interaction);
+      await pactSetUp.provider.addInteraction(interaction);
+    });
+
+    after(async () => {
+      await pactSetUp.provider.finalize();
     });
 
     it('returns the correct response', async () => {
       const caseUrl: string = `${pactSetUp.provider.mockService.baseUrl}/case-assignments?case_ids=[123456789]`;
 
-      const resp = getCases(caseUrl);
-
-      resp.then((response) => {
-        const responseDto: CCDRawCaseUserModel[] = <CCDRawCaseUserModel[]>response.data.case_assignments;
-        assertResponse(responseDto);
-      }).then(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      }).finally(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      });
+      const response = await getCases(caseUrl);
+      const responseDto: CCDRawCaseUserModel[] = <CCDRawCaseUserModel[]>response.data.case_assignments;
+      assertResponse(responseDto);
+      await pactSetUp.provider.verify();
     });
 
     function assertResponse(dto: CCDRawCaseUserModel[]): void {
       expect(dto).to.be.not.null;
       expect(dto[0].case_id).to.equal('123456789');
       expect(dto[0].case_title).to.equal('Case 1');
-      expect(dto[0].shared_with[0].case_roles).to.equal([]);
+      expect(dto[0].shared_with[0].case_roles).to.deep.equal([]);
       expect(dto[0].shared_with[0].first_name).to.equal('Joe');
     }
 

--- a/api/test/pact/pact-tests/aacCaseAssignment/handleCaaCaseTypes.spec.ts
+++ b/api/test/pact/pact-tests/aacCaseAssignment/handleCaaCaseTypes.spec.ts
@@ -7,7 +7,7 @@ const { somethingLike } = Matchers;
 const pactSetUp = new PactTestSetup({ provider: 'acc_manageCaseAssignment', port: 8000 });
 
 describe('Handle unassigned case types ', () => {
-  describe('Handles caa case types', async () => {
+  describe('Handles caa case types', () => {
     // have kept similar structure to payload in function that calls API but may be discrepancies in understanding
     const mockPayload = {
       _source: false,
@@ -83,31 +83,27 @@ describe('Handle unassigned case types ', () => {
         }
       };
       // @ts-ignore
-      pactSetUp.provider.addInteraction(interaction);
+      await pactSetUp.provider.addInteraction(interaction);
+    });
+
+    after(async () => {
+      await pactSetUp.provider.finalize();
     });
 
     it('returns the correct response', async () => {
       const caseUrl: string = `${pactSetUp.provider.mockService.baseUrl}/ccd/searchCases?ctid=MoneyClaimCase,DIVORCE,FinancialRemedyContested,FinancialRemedyMVP2,Asylum,Caveat,GrantOfRepresentation,StandingSearch,WillLodgement,CARE_SUPERVISION_EPO,Benefit,NFD`;
 
-      const resp = handleCaaCaseTypes(caseUrl, mockPayload);
-
-      resp.then((response) => {
-        const responseDto: any[] = <any>response.data;
-        assertResponse(responseDto);
-      }).then(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      }).finally(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      });
+      const response = await handleCaaCaseTypes(caseUrl, mockPayload);
+      const responseDto = response.data;
+      assertResponse(responseDto);
+      await pactSetUp.provider.verify();
     });
 
     function assertResponse(dto: any): void {
       expect(dto).to.be.not.null;
       expect(dto.total).to.equal(2);
       expect(dto.cases[0].case_id).to.equal('case 1');
-      expect(dto[0].case_types_results).to.equal([]);
+      expect(dto.case_types_results).to.deep.equal([]);
     }
 
     const caseResponse = {

--- a/api/test/pact/pact-tests/feePayApi/getAccounts.spec.ts
+++ b/api/test/pact/pact-tests/feePayApi/getAccounts.spec.ts
@@ -42,7 +42,11 @@ describe('Payment API interaction for get account', () => {
         }
       };
       // @ts-ignore
-      pactSetUp.provider.addInteraction(interaction);
+      await pactSetUp.provider.addInteraction(interaction);
+    });
+
+    after(async () => {
+      await pactSetUp.provider.finalize();
     });
 
     it('returns the correct response', async () => {
@@ -50,17 +54,10 @@ describe('Payment API interaction for get account', () => {
 
       const taskUrl: string = `${pactSetUp.provider.mockService.baseUrl}/accounts/` + accountId;
 
-      const resp = getAccountFeeAndPayApi(taskUrl);
-      resp.then((response) => {
-        const responseDto: FeeAccount = <FeeAccount>response.data;
-        assertResponse(responseDto);
-      }).then(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      }).finally(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      });
+      const response = await getAccountFeeAndPayApi(taskUrl);
+      const responseDto: FeeAccount = <FeeAccount>response.data;
+      assertResponse(responseDto);
+      await pactSetUp.provider.verify();
     });
   });
 });

--- a/api/test/pact/pact-tests/idamApi/getUserDetails.spec.ts
+++ b/api/test/pact/pact-tests/idamApi/getUserDetails.spec.ts
@@ -6,7 +6,7 @@ const { Matchers } = require('@pact-foundation/pact');
 const { somethingLike } = Matchers;
 const pactSetUp = new PactTestSetup({ provider: 'idamApi_users', port: 8000 });
 
-describe('Idam API user details', async () => {
+describe('Idam API user details', () => {
   const RESPONSE_BODY = {
     'id': somethingLike('abc123'),
     'forename': somethingLike('Joe'),
@@ -42,24 +42,19 @@ describe('Idam API user details', async () => {
         }
       };
       // @ts-ignore
-      pactSetUp.provider.addInteraction(interaction);
+      await pactSetUp.provider.addInteraction(interaction);
+    });
+
+    after(async () => {
+      await pactSetUp.provider.finalize();
     });
 
     it('returns the correct response', async () => {
       const taskUrl = `${pactSetUp.provider.mockService.baseUrl}`;
 
-      const response: Promise<any> = getDetails(taskUrl, jwt);
-
-      response.then((axiosResponse) => {
-        const dto: IdamGetDetailsResponseDto = <IdamGetDetailsResponseDto>axiosResponse;
-        assertResponses(dto);
-      }).then(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      }).finally(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      });
+      const response: IdamGetDetailsResponseDto = await getDetails(taskUrl, jwt);
+      assertResponses(response);
+      await pactSetUp.provider.verify();
     });
   });
 });

--- a/api/test/pact/pact-tests/rdProfessionalApi/editUserPermissions.spec.ts
+++ b/api/test/pact/pact-tests/rdProfessionalApi/editUserPermissions.spec.ts
@@ -8,7 +8,7 @@ const { somethingLike } = Matchers;
 const pactSetUp = new PactTestSetup({ provider: 'referenceData_professionalExternalUsers', port: 8000 });
 
 describe('RD Professional API', () => {
-  describe('Edit UserPermssions given userId', async () => {
+  describe('Edit UserPermssions given userId', () => {
     const userId = '123456';
 
     const mockRequest = {
@@ -56,25 +56,21 @@ describe('RD Professional API', () => {
         }
       };
       // @ts-ignore
-      pactSetUp.provider.addInteraction(interaction);
+      await pactSetUp.provider.addInteraction(interaction);
+    });
+
+    after(async () => {
+      await pactSetUp.provider.finalize();
     });
 
     it('Returns the correct response', async () => {
       // call the pactUtil's method which Calls The Downstream API directly without going through the Service Class.
 
       const taskUrl: string = `${pactSetUp.provider.mockService.baseUrl}/refdata/external/v1/organisations/users/` + userId;
-      const resp = editUserPermissions(taskUrl, mockRequest as any);
-
-      resp.then((response) => {
-        const responseDto: EditUserPermissionsDto = <EditUserPermissionsDto>response.data;
-        assertResponse(responseDto);
-      }).then(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      }).finally(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      });
+      const response = await editUserPermissions(taskUrl, mockRequest as any);
+      const responseDto: EditUserPermissionsDto = <EditUserPermissionsDto>response.data;
+      assertResponse(responseDto);
+      await pactSetUp.provider.verify();
     });
   });
 });

--- a/api/test/pact/pact-tests/rdProfessionalApi/getOrganisationDetails.spec.ts
+++ b/api/test/pact/pact-tests/rdProfessionalApi/getOrganisationDetails.spec.ts
@@ -8,7 +8,7 @@ const { somethingLike, eachLike } = Matchers;
 const pactSetUp = new PactTestSetup({ provider: 'referenceData_organisationalExternalUsers', port: 8000 });
 
 describe('Get Organisation Details from RDProfessionalAPI ', () => {
-  describe('Get Organisation Details', async () => {
+  describe('Get Organisation Details', () => {
     before(async () => {
       await pactSetUp.provider.setup();
       const interaction = {
@@ -34,24 +34,20 @@ describe('Get Organisation Details from RDProfessionalAPI ', () => {
         }
       };
       // @ts-ignore
-      pactSetUp.provider.addInteraction(interaction);
+      await pactSetUp.provider.addInteraction(interaction);
+    });
+
+    after(async () => {
+      await pactSetUp.provider.finalize();
     });
 
     it('returns the correct response', async () => {
       const taskUrl: string = `${pactSetUp.provider.mockService.baseUrl}/refdata/external/v1/organisations`;
 
-      const resp = getOrganisationDetails(taskUrl);
-
-      resp.then((response) => {
-        const responseDto: Organisation = <Organisation>response.data;
-        assertResponse(responseDto);
-      }).then(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      }).finally(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      });
+      const response = await getOrganisationDetails(taskUrl);
+      const responseDto: Organisation = <Organisation>response.data;
+      assertResponse(responseDto);
+      await pactSetUp.provider.verify();
     });
 
     function assertResponse(dto: Organisation): void {

--- a/api/test/pact/pact-tests/rdProfessionalApi/inviteUserPost.spec.ts
+++ b/api/test/pact/pact-tests/rdProfessionalApi/inviteUserPost.spec.ts
@@ -47,22 +47,19 @@ describe('RD Professional API', () => {
         }
       };
       // @ts-ignore
-      pactSetUp.provider.addInteraction(interaction);
+      await pactSetUp.provider.addInteraction(interaction);
+    });
+
+    after(async () => {
+      await pactSetUp.provider.finalize();
     });
 
     it('returns the correct response', async () => {
       const taskUrl: string = `${pactSetUp.provider.mockService.baseUrl}/refdata/external/v1/organisations/users/`;
-      const resp = inviteUser(taskUrl, mockRequest as any);
-      resp.then((response) => {
-        const responseDto: InviteUserResponse = <InviteUserResponse>response.data;
-        assertResponse(responseDto);
-      }).then(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      }).finally(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      });
+      const response = await inviteUser(taskUrl, mockRequest as any);
+      const responseDto: InviteUserResponse = <InviteUserResponse>response.data;
+      assertResponse(responseDto);
+      await pactSetUp.provider.verify();
     });
   });
 });

--- a/api/test/pact/pact-tests/rdProfessionalApi/registerOrgPostExternal.spec.ts
+++ b/api/test/pact/pact-tests/rdProfessionalApi/registerOrgPostExternal.spec.ts
@@ -8,7 +8,7 @@ const { somethingLike } = Matchers;
 const pactSetUp = new PactTestSetup({ provider: 'referenceData_organisationalExternalUsers', port: 8000 });
 
 describe('Register External Organisation', () => {
-  describe('Register External Organisation', async () => {
+  describe('Register External Organisation', () => {
     const mockRequest = {
       'name': 'Joe Blogg',
       'status': 'ACTIVE',
@@ -72,24 +72,20 @@ describe('Register External Organisation', () => {
         }
       };
       // @ts-ignore
-      pactSetUp.provider.addInteraction(interaction);
+      await pactSetUp.provider.addInteraction(interaction);
     });
 
-    it('Returns the correct response', async() => {
-      const taskUrl: string = `${pactSetUp.provider.mockService.baseUrl}/refdata/external/v1/organisations`;
-      const resp = registerOrganisationExternalV1(taskUrl, mockRequest as any);
+    after(async () => {
+      await pactSetUp.provider.finalize();
+    });
 
-      resp.then((response) => {
-        expect(response.status).to.equal(201);
-        const responseDto: OrganisationCreatedResponse = <OrganisationCreatedResponse> response.data;
-        assertResponse(responseDto);
-      }).then(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      }).finally(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      });
+    it('Returns the correct response', async () => {
+      const taskUrl: string = `${pactSetUp.provider.mockService.baseUrl}/refdata/external/v1/organisations`;
+      const response = await registerOrganisationExternalV1(taskUrl, mockRequest as any);
+      expect(response.status).to.equal(201);
+      const responseDto: OrganisationCreatedResponse = <OrganisationCreatedResponse> response.data;
+      assertResponse(responseDto);
+      await pactSetUp.provider.verify();
     });
   });
 });

--- a/api/test/pact/pact-tests/rdProfessionalApi/suspendUser.spec.ts
+++ b/api/test/pact/pact-tests/rdProfessionalApi/suspendUser.spec.ts
@@ -8,7 +8,7 @@ const { somethingLike } = Matchers;
 const pactSetUp = new PactTestSetup({ provider: 'referenceData_professionalExternalUsers', port: 8000 });
 
 describe('RD Professional API', () => {
-  describe('Suspend A User', async () => {
+  describe('Suspend A User', () => {
     const mockRequest = {
       'email': 'Joe.bloggs@mailnesia.com',
       'firstName': 'Joe',
@@ -54,7 +54,11 @@ describe('RD Professional API', () => {
         }
       };
       // @ts-ignore
-      pactSetUp.provider.addInteraction(interaction);
+      await pactSetUp.provider.addInteraction(interaction);
+    });
+
+    after(async () => {
+      await pactSetUp.provider.finalize();
     });
 
     it('returns the correct response', async () => {
@@ -62,18 +66,10 @@ describe('RD Professional API', () => {
       const userId = '123456';
       const taskUrl: string = `${pactSetUp.provider.mockService.baseUrl}/refdata/external/v1/organisations/users/` + userId;
 
-      const resp = suspendUser(taskUrl, mockRequest as any);
-
-      resp.then((response) => {
-        const responseDto: SuspendUserReponseDto = <SuspendUserReponseDto>response.data;
-        assertResponse(responseDto);
-      }).then(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      }).finally(() => {
-        pactSetUp.provider.verify();
-        pactSetUp.provider.finalize();
-      });
+      const response = await suspendUser(taskUrl, mockRequest as any);
+      const responseDto: SuspendUserReponseDto = <SuspendUserReponseDto>response.data;
+      assertResponse(responseDto);
+      await pactSetUp.provider.verify();
     });
   });
 });


### PR DESCRIPTION
### Jira link

See [EXUI-4638](https://tools.hmcts.net/jira/browse/EXUI-4638)

### Change description ###

- Refactored all runnable Manage Organisations Pact specs to use `async`/`await` instead of floating `.then()` chains.
- Awaited `addInteraction`, service calls, response assertions, `provider.verify()`, and `provider.finalize()`.
- Removed async `describe` callbacks that Mocha does not await.
- Corrected two assertions that were exposed once the tests genuinely awaited their responses.

This restores confidence in the Pact consumer gate by preventing Mocha from reporting a green result before contract assertions and Pact verification complete.

### Testing done

Automated:

- [x] `yarn test-pact` - PASS, 9 passing
- [x] `yarn lint:node` - PASS
- [x] `git diff --check origin/master` - PASS
- [x] `yarn npm audit --recursive --environment production --json > yarn-audit-known-issues` - completed with exit code 1 as expected for existing advisories; output parsed as 57 JSON lines and tracked file did not change

Manual:

- [x] Reviewed the branch diff for remaining floating Pact promises, async `describe` callbacks, duplicate lifecycle calls, and scope creep.

Evidence:

- HTML: N/A
- Odhin: N/A
- JUnit: N/A
- Pact artifacts generated locally under `api/test/pact/pacts/` and `api/test/pact/logs/`; not committed.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
