### PR TITLE
EXUI-4642: Harden Playwright retirement runners

### DIFF
--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -73,6 +73,51 @@ def publishPlaywrightReport = { String reportDir, String reportFile, String repo
     archiveArtifacts allowEmptyArchive: true, artifacts: artifacts
 }
 
+def stagePlaywrightArtifacts = { String stageDir, String sourceDir ->
+    withEnv([
+        "PW_ARTIFACT_STAGE_DIR=${stageDir}",
+        "PW_ARTIFACT_SOURCE_DIR=${sourceDir}"
+    ]) {
+        sh '''
+            set -eu
+            rm -rf "$PW_ARTIFACT_STAGE_DIR"
+            mkdir -p "$PW_ARTIFACT_STAGE_DIR"
+
+            if [ -d "$PW_ARTIFACT_SOURCE_DIR" ]; then
+              source_abs="$(cd "$PW_ARTIFACT_SOURCE_DIR" && pwd)"
+              file_list="$(mktemp)"
+              find "$source_abs" -path '*/.playwright-artifacts-*' -prune -o -type f -print 2>/dev/null > "$file_list"
+              copied=0
+              failed=0
+              while IFS= read -r file; do
+                case "$file" in
+                  *.png|*.webm|*.zip|*/error-context.md|*/node-api-calls.json|*/node-api-calls.pretty.txt)
+                    if [ ! -f "$file" ]; then
+                      failed=$((failed + 1))
+                      continue
+                    fi
+                    relative="${file#$source_abs/}"
+                    target="$PW_ARTIFACT_STAGE_DIR/$relative"
+                    mkdir -p "$(dirname "$target")"
+                    if cp "$file" "$target"; then
+                      copied=$((copied + 1))
+                    else
+                      failed=$((failed + 1))
+                    fi
+                    ;;
+                esac
+              done < "$file_list"
+              rm -f "$file_list"
+              echo "Staged $copied Playwright artifact(s) from $PW_ARTIFACT_SOURCE_DIR to $PW_ARTIFACT_STAGE_DIR"
+              if [ "$failed" -gt 0 ]; then
+                echo "Failed to stage $failed Playwright artifact(s) from $PW_ARTIFACT_SOURCE_DIR"
+                exit 1
+              fi
+            fi
+        '''
+    }
+}
+
 def runPlaywrightFunctionalTests = { String environmentName ->
     stage("${environmentName} Playwright Functional Replacement") {
         try {
@@ -128,24 +173,34 @@ def runPlaywrightFunctionalTests = { String environmentName ->
                 }
             )
         } finally {
+            stagePlaywrightArtifacts('functional-output/tests/playwright-api/stable-artifacts', 'test-results/playwright-api')
             publishPlaywrightReport(
                 "functional-output/tests/playwright-api/odhin-report",
                 'xui-mo-playwright-api.html',
                 "${environmentName} Manage Org Playwright API",
                 'functional-output/tests/playwright-api/**'
             )
+            stagePlaywrightArtifacts('functional-output/tests/playwright-integration/stable-artifacts', 'test-results/playwright-integration')
             publishPlaywrightReport(
                 "functional-output/tests/playwright-integration/odhin-report",
                 'xui-mo-playwright-integration.html',
                 "${environmentName} Manage Org Playwright Integration",
                 'functional-output/tests/playwright-integration/**'
             )
+            stagePlaywrightArtifacts('functional-output/tests/playwright-a11y/stable-artifacts', 'test-results/playwright-a11y')
             publishPlaywrightReport(
                 "functional-output/tests/playwright-a11y/odhin-report",
                 'xui-playwright-a11y.html',
                 "${environmentName} Manage Org Register Organisation Playwright A11y",
                 'functional-output/tests/playwright-a11y/**'
             )
+            publishPlaywrightReport(
+                "functional-output/tests/playwright-a11y/integration/odhin-report",
+                'xui-playwright-a11y-integration.html',
+                "${environmentName} Manage Org Register Organisation Playwright A11y - Integration",
+                'functional-output/tests/playwright-a11y/integration/**'
+            )
+            stagePlaywrightArtifacts('functional-output/tests/playwright-e2e/stable-artifacts', 'test-results/playwright-e2e')
             publishPlaywrightReport(
                 "functional-output/tests/playwright-e2e/odhin-report",
                 'xui-playwright-e2e.html',
@@ -192,6 +247,7 @@ withParameterizedPipeline(type, product, component, params.ENVIRONMENT, 'sandbox
     }
 
     after('test') {
+        sh 'yarn test:coverage:node'
 
         publishHTML ( [
             allowMissing         : true,
@@ -215,7 +271,7 @@ withParameterizedPipeline(type, product, component, params.ENVIRONMENT, 'sandbox
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
             keepAll              : true,
-            reportDir            : "test/reports/tests/coverage/node",
+            reportDir            : "reports/tests/coverage/node",
             reportFiles          : "index.html",
             reportName           : "node coverage tests"
         ])

--- a/playwright_tests_new/api/unit/retirement-scripts.unit.api.ts
+++ b/playwright_tests_new/api/unit/retirement-scripts.unit.api.ts
@@ -1,0 +1,112 @@
+import { expect, test } from '@playwright/test';
+import path from 'node:path';
+
+let a11yRunner: {
+  buildRunPlan: (
+    argv: string[],
+    env: Record<string, string | undefined>
+  ) => {
+    functionalOutputRoot: string;
+    runs: Array<{ args: string[]; env: Record<string, string | undefined>; label: string }>;
+    testOutputRoot: string;
+  };
+  resolveSafeOutputRoot: (configuredPath: string, label: string) => string;
+  runYarn: (
+    label: string,
+    args: string[],
+    envOverrides: Record<string, string | undefined>,
+    env: Record<string, string | undefined>,
+    spawn: (command: string, args: string[], options: { env: Record<string, string | undefined> }) => { status: number }
+  ) => number;
+};
+
+let retiredRunner: {
+  resolveRetiredRunnerOutcome: (mode: string, command: string) => { bridge: boolean; exitCode: number; reason: string };
+};
+
+test.describe('Manage Org Playwright retirement scripts', { tag: '@svc-internal' }, () => {
+  test.beforeAll(async () => {
+    const a11yModule = await import('../../../scripts/run-playwright-a11y.js');
+    a11yRunner = (a11yModule.default ?? a11yModule) as typeof a11yRunner;
+
+    const retiredModule = await import('../../../scripts/retired-codecept-runner.js');
+    retiredRunner = (retiredModule.default ?? retiredModule) as typeof retiredRunner;
+  });
+
+  test('only permits the explicit shared functional bridge commands', () => {
+    expect(retiredRunner.resolveRetiredRunnerOutcome('bridge', 'test:functional')).toMatchObject({
+      bridge: true,
+      exitCode: 0
+    });
+    expect(retiredRunner.resolveRetiredRunnerOutcome('bridge', 'test:fullfunctional')).toMatchObject({
+      bridge: true,
+      exitCode: 0
+    });
+    expect(retiredRunner.resolveRetiredRunnerOutcome('bridge', 'test:api')).toMatchObject({
+      bridge: false,
+      exitCode: 1
+    });
+    expect(retiredRunner.resolveRetiredRunnerOutcome('fail', 'test:api')).toMatchObject({
+      bridge: false,
+      exitCode: 1
+    });
+  });
+
+  test('keeps the a11y runner scoped to @a11y even when caller env tags exclude it', () => {
+    const plan = a11yRunner.buildRunPlan(['--project=chromium'], {
+      PLAYWRIGHT_EXCLUDE_TAGS: '@a11y',
+      PLAYWRIGHT_TAGS: '@e2e'
+    });
+
+    expect(plan.runs).toHaveLength(4);
+    expect(plan.runs.map((run) => run.args)).toEqual([
+      ['test:playwrightE2E:list', '--grep', '@a11y', '--project=chromium'],
+      ['test:playwrightE2E:raw', '--', '--grep', '@a11y', '--project=chromium'],
+      ['test:playwright:integration:raw', '--', '--list', '--grep', '@a11y', '--project=chromium'],
+      ['test:playwright:integration:raw', '--', '--grep', '@a11y', '--project=chromium']
+    ]);
+  });
+
+  test('clears inherited tag env when spawning a11y runs', () => {
+    let capturedEnv: Record<string, string | undefined> = {};
+
+    const status = a11yRunner.runYarn(
+      'dry run',
+      ['--version'],
+      {},
+      {
+        PLAYWRIGHT_EXCLUDE_TAGS: '@a11y',
+        PLAYWRIGHT_TAGS: '@e2e'
+      },
+      (_command, _args, options) => {
+        capturedEnv = options.env;
+        return { status: 0 };
+      }
+    );
+
+    expect(status).toBe(0);
+    expect(capturedEnv.PLAYWRIGHT_EXCLUDE_TAGS).toBe('');
+    expect(capturedEnv.PLAYWRIGHT_INCLUDE_A11Y).toBe('true');
+    expect(capturedEnv.PLAYWRIGHT_TAGS).toBe('');
+    expect(capturedEnv.PW_ODHIN_FORCE_EXIT_ON_COMPLETION).toBe('true');
+  });
+
+  test('rejects caller grep overrides that would widen a11y execution', () => {
+    expect(() => a11yRunner.buildRunPlan(['--grep', '@registration'], {})).toThrow(/Do not pass --grep/);
+    expect(() => a11yRunner.buildRunPlan(['--grep-invert=@a11y'], {})).toThrow(/Do not pass --grep-invert=/);
+    expect(() => a11yRunner.buildRunPlan(['-g', '@e2e'], {})).toThrow(/Do not pass -g/);
+  });
+
+  test('refuses to clean output roots outside the runner-owned directories', () => {
+    expect(() => a11yRunner.resolveSafeOutputRoot(path.resolve('.'), 'root')).toThrow(/refusing to recursively delete/);
+    expect(() => a11yRunner.resolveSafeOutputRoot('/tmp/playwright-a11y', 'tmp')).toThrow(
+      /must stay under functional-output\/tests\/playwright-a11y or test-results\/playwright-a11y/
+    );
+    expect(a11yRunner.resolveSafeOutputRoot('functional-output/tests/playwright-a11y/html-report', 'html')).toBe(
+      'functional-output/tests/playwright-a11y/html-report'
+    );
+    expect(a11yRunner.resolveSafeOutputRoot('test-results/playwright-a11y/integration', 'test-results')).toBe(
+      'test-results/playwright-a11y/integration'
+    );
+  });
+});

--- a/scripts/check-playwright-architecture.js
+++ b/scripts/check-playwright-architecture.js
@@ -34,6 +34,7 @@ const activePipelineFiles = [
   'Jenkinsfile_nightly',
   'Jenkinsfile_parameterized'
 ];
+const parameterizedPipelineFile = 'Jenkinsfile_parameterized';
 const retiredExecutionPatterns = [
   { pattern: /\bnpx\s+codeceptjs\b/, label: 'CodeceptJS runner' },
   { pattern: /\bcodeceptjs\s+run(?:-workers)?\b/, label: 'CodeceptJS runner' },
@@ -147,6 +148,39 @@ for (const fileName of activePipelineFiles) {
     if (pattern.test(pipelineSource)) {
       failures.push(`${fileName}: contains ${label}; pipelines must run only Playwright retirement lanes.`);
     }
+  }
+}
+
+const retiredRunnerSource = readFileSync(join(root, 'scripts/retired-codecept-runner.js'), 'utf-8');
+if (!/mode\s*===\s*['"]bridge['"]\s*&&\s*bridgeCommands\.has\(command\)/.test(retiredRunnerSource)) {
+  failures.push(
+    'scripts/retired-codecept-runner.js: bridge mode must only succeed for the explicit shared Jenkins bridge commands.'
+  );
+}
+
+const a11yRunnerSource = readFileSync(join(root, 'scripts/run-playwright-a11y.js'), 'utf-8');
+for (const expectedContract of [
+  'assertNoGrepOverrides',
+  'resolveSafeOutputRoot',
+  'PLAYWRIGHT_EXCLUDE_TAGS',
+  'PLAYWRIGHT_TAGS',
+  'PW_ODHIN_FORCE_EXIT_ON_COMPLETION'
+]) {
+  if (!a11yRunnerSource.includes(expectedContract)) {
+    failures.push(`scripts/run-playwright-a11y.js: missing a11y runner hardening contract ${expectedContract}.`);
+  }
+}
+
+const parameterizedPipelineSource = readFileSync(join(root, parameterizedPipelineFile), 'utf-8');
+for (const expectedEvidencePath of [
+  'functional-output/tests/playwright-a11y/integration/odhin-report',
+  'xui-playwright-a11y-integration.html',
+  'stagePlaywrightArtifacts',
+  "sh 'yarn test:coverage:node'",
+  'reports/tests/coverage/node'
+]) {
+  if (!parameterizedPipelineSource.includes(expectedEvidencePath)) {
+    failures.push(`${parameterizedPipelineFile}: missing Playwright retirement evidence contract ${expectedEvidencePath}.`);
   }
 }
 

--- a/scripts/retired-codecept-runner.js
+++ b/scripts/retired-codecept-runner.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-const [mode = 'fail', command = 'legacy Codecept runner'] = process.argv.slice(2);
-
 const replacements = [
   'yarn test:api:pw',
   'yarn test:playwright:integration',
@@ -10,18 +8,54 @@ const replacements = [
 ];
 
 const bridgeCommands = new Set(['test:functional', 'test:fullfunctional']);
-const isBridge = mode === 'bridge' || bridgeCommands.has(command);
 
-console.log(`Legacy Manage Org functional runner "${command}" is retired.`);
-console.log('Authoritative Manage Org functional gates now run through Playwright:');
-for (const replacement of replacements) {
-  console.log(`- ${replacement}`);
+const resolveRetiredRunnerOutcome = (mode = 'fail', command = 'legacy Codecept runner') => {
+  const isBridge = mode === 'bridge' && bridgeCommands.has(command);
+  const isFailMode = mode === 'fail';
+
+  if (isBridge) {
+    return {
+      bridge: true,
+      exitCode: 0,
+      reason: 'This shared Jenkins hook is intentionally a no-op bridge to avoid duplicate Playwright execution.'
+    };
+  }
+
+  return {
+    bridge: false,
+    exitCode: 1,
+    reason: isFailMode
+      ? `"${command}" must not be used for new validation. Use the Playwright replacement above.`
+      : `"${command}" is not an allowed retired-runner bridge command.`
+  };
+};
+
+const run = (argv = process.argv.slice(2), logger = console) => {
+  const [mode = 'fail', command = 'legacy Codecept runner'] = argv;
+  const outcome = resolveRetiredRunnerOutcome(mode, command);
+
+  logger.log(`Legacy Manage Org functional runner "${command}" is retired.`);
+  logger.log('Authoritative Manage Org functional gates now run through Playwright:');
+  for (const replacement of replacements) {
+    logger.log(`- ${replacement}`);
+  }
+
+  if (outcome.bridge) {
+    logger.log(outcome.reason);
+  } else {
+    logger.error(outcome.reason);
+  }
+
+  return outcome.exitCode;
+};
+
+if (require.main === module) {
+  process.exit(run());
 }
 
-if (isBridge) {
-  console.log('This shared Jenkins hook is intentionally a no-op bridge to avoid duplicate Playwright execution.');
-  process.exit(0);
-}
-
-console.error(`"${command}" must not be used for new validation. Use the Playwright replacement above.`);
-process.exit(1);
+module.exports = {
+  bridgeCommands,
+  replacements,
+  resolveRetiredRunnerOutcome,
+  run
+};

--- a/scripts/run-playwright-a11y.js
+++ b/scripts/run-playwright-a11y.js
@@ -2,23 +2,134 @@
 
 const { spawnSync } = require('node:child_process');
 const { rmSync } = require('node:fs');
+const { homedir } = require('node:os');
+const path = require('node:path');
 
-const passthroughArgs = process.argv.slice(2).filter((arg) => arg !== '--');
-const functionalOutputRoot = process.env.PLAYWRIGHT_A11Y_OUTPUT_ROOT || 'functional-output/tests/playwright-a11y';
-const testOutputRoot = process.env.PLAYWRIGHT_TEST_OUTPUT_DIR || 'test-results/playwright-a11y';
+const defaultFunctionalOutputRoot = 'functional-output/tests/playwright-a11y';
+const defaultTestOutputRoot = 'test-results/playwright-a11y';
+const ownedOutputRoots = [
+  path.resolve(defaultFunctionalOutputRoot),
+  path.resolve(defaultTestOutputRoot)
+];
 
-rmSync(functionalOutputRoot, { force: true, recursive: true });
-rmSync(testOutputRoot, { force: true, recursive: true });
+const normalizePassthroughArgs = (argv) => argv.filter((arg) => arg !== '--');
 
-const runYarn = (label, args, envOverrides) => {
+const hasForbiddenGrepOverride = (arg) =>
+  arg === '-g' ||
+  arg === '--grep' ||
+  arg === '--grep-invert' ||
+  arg.startsWith('-g=') ||
+  arg.startsWith('--grep=') ||
+  arg.startsWith('--grep-invert=');
+
+const assertNoGrepOverrides = (args) => {
+  const override = args.find(hasForbiddenGrepOverride);
+  if (override) {
+    throw new Error(
+      `Do not pass ${override} to test:a11y:playwright. The a11y runner owns the @a11y grep so retired non-a11y tests cannot be reintroduced.`
+    );
+  }
+};
+
+const isWithin = (root, candidate) => {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+};
+
+const resolveSafeOutputRoot = (configuredPath, label) => {
+  if (!configuredPath || configuredPath.trim() === '') {
+    throw new Error(`${label} must not be empty.`);
+  }
+
+  const resolved = path.resolve(configuredPath);
+  const unsafeRoots = new Set([path.resolve('.'), path.resolve(path.sep), homedir()]);
+  if (unsafeRoots.has(resolved)) {
+    throw new Error(`${label} resolves to ${resolved}; refusing to recursively delete that path.`);
+  }
+
+  if (!ownedOutputRoots.some((ownedRoot) => isWithin(ownedRoot, resolved))) {
+    throw new Error(
+      `${label} must stay under ${defaultFunctionalOutputRoot} or ${defaultTestOutputRoot}; received ${configuredPath}.`
+    );
+  }
+
+  return configuredPath;
+};
+
+const buildRunPlan = (argv = process.argv.slice(2), env = process.env) => {
+  const passthroughArgs = normalizePassthroughArgs(argv);
+  assertNoGrepOverrides(passthroughArgs);
+
+  const functionalOutputRoot = resolveSafeOutputRoot(
+    env.PLAYWRIGHT_A11Y_OUTPUT_ROOT || defaultFunctionalOutputRoot,
+    'PLAYWRIGHT_A11Y_OUTPUT_ROOT'
+  );
+  const testOutputRoot = resolveSafeOutputRoot(
+    env.PLAYWRIGHT_TEST_OUTPUT_DIR || defaultTestOutputRoot,
+    'PLAYWRIGHT_TEST_OUTPUT_DIR'
+  );
+
+  const e2eEnv = {
+    PLAYWRIGHT_TEST_OUTPUT_DIR: testOutputRoot,
+    PLAYWRIGHT_HTML_OUTPUT: env.PLAYWRIGHT_HTML_OUTPUT || `${functionalOutputRoot}/html-report`,
+    PLAYWRIGHT_JUNIT_OUTPUT: env.PLAYWRIGHT_JUNIT_OUTPUT || `${functionalOutputRoot}/playwright-a11y-junit.xml`,
+    PLAYWRIGHT_REPORT_FOLDER: env.PLAYWRIGHT_REPORT_FOLDER || `${functionalOutputRoot}/odhin-report`,
+    PLAYWRIGHT_REPORT_INDEX_FILENAME: env.PLAYWRIGHT_REPORT_INDEX_FILENAME || 'xui-playwright-a11y.html',
+    PLAYWRIGHT_REPORT_PROJECT: env.PLAYWRIGHT_REPORT_PROJECT || 'RPX XUI Manage Organisations - Accessibility',
+    PLAYWRIGHT_REPORT_TITLE: env.PLAYWRIGHT_REPORT_TITLE || 'RPX XUI Manage Organisations Playwright A11y'
+  };
+
+  const integrationEnv = {
+    PLAYWRIGHT_TEST_OUTPUT_DIR: `${testOutputRoot}/integration`,
+    PLAYWRIGHT_HTML_OUTPUT: `${functionalOutputRoot}/integration/html-report`,
+    PLAYWRIGHT_JUNIT_OUTPUT: `${functionalOutputRoot}/integration/playwright-a11y-integration-junit.xml`,
+    PLAYWRIGHT_REPORT_FOLDER: `${functionalOutputRoot}/integration/odhin-report`,
+    PLAYWRIGHT_REPORT_INDEX_FILENAME: 'xui-playwright-a11y-integration.html',
+    PLAYWRIGHT_REPORT_PROJECT: 'RPX XUI Manage Organisations - Integration Accessibility',
+    PLAYWRIGHT_REPORT_TITLE: 'RPX XUI Manage Organisations Playwright Integration A11y'
+  };
+
+  return {
+    functionalOutputRoot,
+    passthroughArgs,
+    runs: [
+      {
+        args: ['test:playwrightE2E:list', '--grep', '@a11y', ...passthroughArgs],
+        env: e2eEnv,
+        label: 'E2E a11y discovery'
+      },
+      {
+        args: ['test:playwrightE2E:raw', '--', '--grep', '@a11y', ...passthroughArgs],
+        env: e2eEnv,
+        label: 'E2E a11y execution'
+      },
+      {
+        args: ['test:playwright:integration:raw', '--', '--list', '--grep', '@a11y', ...passthroughArgs],
+        env: integrationEnv,
+        label: 'integration a11y discovery'
+      },
+      {
+        args: ['test:playwright:integration:raw', '--', '--grep', '@a11y', ...passthroughArgs],
+        env: integrationEnv,
+        label: 'integration a11y execution'
+      }
+    ],
+    testOutputRoot
+  };
+};
+
+const runYarn = (label, args, envOverrides, env = process.env, spawn = spawnSync) => {
   console.log(`[playwright-a11y] ${label}`);
 
-  const result = spawnSync('yarn', args, {
+  const result = spawn('yarn', args, {
     env: {
-      ...process.env,
-      FUNCTIONAL_TESTS_WORKERS: process.env.FUNCTIONAL_TESTS_WORKERS || '4',
+      ...env,
+      FUNCTIONAL_TESTS_WORKERS: env.FUNCTIONAL_TESTS_WORKERS || '4',
+      ...envOverrides,
       PLAYWRIGHT_INCLUDE_A11Y: 'true',
-      ...envOverrides
+      PLAYWRIGHT_EXCLUDE_TAGS: '',
+      PLAYWRIGHT_TAGS: '',
+      PW_ODHIN_FORCE_EXIT_ON_COMPLETION: env.PW_ODHIN_FORCE_EXIT_ON_COMPLETION || 'true'
     },
     shell: process.platform === 'win32',
     stdio: 'inherit'
@@ -30,43 +141,42 @@ const runYarn = (label, args, envOverrides) => {
 
   if (result.signal) {
     console.error(`[playwright-a11y] ${label} terminated by signal ${result.signal}`);
-    process.exit(1);
+    return 1;
   }
 
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+  return result.status ?? 1;
+};
+
+const main = (argv = process.argv.slice(2), env = process.env) => {
+  let plan;
+  try {
+    plan = buildRunPlan(argv, env);
+  } catch (error) {
+    console.error(`[playwright-a11y] ${error.message}`);
+    return 1;
   }
+
+  rmSync(plan.functionalOutputRoot, { force: true, recursive: true });
+  rmSync(plan.testOutputRoot, { force: true, recursive: true });
+
+  for (const run of plan.runs) {
+    const status = runYarn(run.label, run.args, run.env, env);
+    if (status !== 0) {
+      return status;
+    }
+  }
+
+  return 0;
 };
 
-const e2eEnv = {
-  PLAYWRIGHT_TEST_OUTPUT_DIR: testOutputRoot,
-  PLAYWRIGHT_HTML_OUTPUT: process.env.PLAYWRIGHT_HTML_OUTPUT || `${functionalOutputRoot}/html-report`,
-  PLAYWRIGHT_JUNIT_OUTPUT: process.env.PLAYWRIGHT_JUNIT_OUTPUT || `${functionalOutputRoot}/playwright-a11y-junit.xml`,
-  PLAYWRIGHT_REPORT_FOLDER: process.env.PLAYWRIGHT_REPORT_FOLDER || `${functionalOutputRoot}/odhin-report`,
-  PLAYWRIGHT_REPORT_INDEX_FILENAME: process.env.PLAYWRIGHT_REPORT_INDEX_FILENAME || 'xui-playwright-a11y.html',
-  PLAYWRIGHT_REPORT_PROJECT: process.env.PLAYWRIGHT_REPORT_PROJECT || 'RPX XUI Manage Organisations - Accessibility',
-  PLAYWRIGHT_REPORT_TITLE: process.env.PLAYWRIGHT_REPORT_TITLE || 'RPX XUI Manage Organisations Playwright A11y'
-};
+if (require.main === module) {
+  process.exit(main());
+}
 
-const integrationEnv = {
-  PLAYWRIGHT_TEST_OUTPUT_DIR: `${testOutputRoot}/integration`,
-  PLAYWRIGHT_HTML_OUTPUT: `${functionalOutputRoot}/integration/html-report`,
-  PLAYWRIGHT_JUNIT_OUTPUT: `${functionalOutputRoot}/integration/playwright-a11y-integration-junit.xml`,
-  PLAYWRIGHT_REPORT_FOLDER: `${functionalOutputRoot}/integration/odhin-report`,
-  PLAYWRIGHT_REPORT_INDEX_FILENAME: 'xui-playwright-a11y-integration.html',
-  PLAYWRIGHT_REPORT_PROJECT: 'RPX XUI Manage Organisations - Integration Accessibility',
-  PLAYWRIGHT_REPORT_TITLE: 'RPX XUI Manage Organisations Playwright Integration A11y'
+module.exports = {
+  assertNoGrepOverrides,
+  buildRunPlan,
+  normalizePassthroughArgs,
+  resolveSafeOutputRoot,
+  runYarn
 };
-
-runYarn('E2E a11y discovery', ['test:playwrightE2E:list', '--grep', '@a11y', ...passthroughArgs], e2eEnv);
-runYarn('E2E a11y execution', ['test:playwrightE2E:raw', '--', '--grep', '@a11y', ...passthroughArgs], e2eEnv);
-runYarn(
-  'integration a11y discovery',
-  ['test:playwright:integration:raw', '--', '--list', '--grep', '@a11y', ...passthroughArgs],
-  integrationEnv
-);
-runYarn(
-  'integration a11y execution',
-  ['test:playwright:integration:raw', '--', '--grep', '@a11y', ...passthroughArgs],
-  integrationEnv
-);


### PR DESCRIPTION
### Jira link

See [EXUI-4642](https://tools.hmcts.net/jira/browse/EXUI-4642)

### Change description ###

- Hardens the retired Codecept bridge so only the explicit shared Jenkins bridge commands can no-op successfully.
- Hardens the Playwright a11y runner so inherited tag filters or caller grep overrides cannot silently widen or suppress the authoritative `@a11y` suite.
- Splits E2E and integration a11y report output so both lanes publish distinct Odhín/HTML evidence.
- Stages Playwright artifacts before Jenkins archiving to avoid unstable transient `.playwright-artifacts-*` archive failures.
- Adds node/API unit coverage for the retirement runner contracts.
- Runs node coverage from the parameterized pipeline and fixes the published coverage path.
- No production `src/` code is changed.
- AI assistance used for implementation and evidence collation; normal human review remains required before merge.

### Value added to our test pack by delivering this ticket ###

- Locks the retired Codecept functional runner out of the active validation path: accidental calls now fail fast, while only the two known shared Jenkins bridge scripts can no-op.
- Protects the new Playwright a11y gate from false greens: caller grep overrides are rejected and inherited tag filters are cleared so the authoritative `@a11y` suite cannot be silently skipped.
- Makes the a11y evidence complete and reviewable: E2E a11y and integration a11y now publish separate HTML, JUnit, and Odhín report locations.
- Improves CI reliability for Playwright evidence: transient `.playwright-artifacts-*` resources are excluded from direct archive traversal and stable artifacts are staged before publishing.
- Adds direct regression coverage for the retirement infrastructure itself, covering the retired runner bridge contract, a11y runner scoping, env isolation, and safe cleanup boundaries.
- Brings parameterized pipeline evidence in line with CNP/nightly retirement expectations by running and publishing node coverage from the same path Jenkins expects.
- Confirms the current replacement suite shape: 47 E2E a11y checks and 2 integration a11y checks are discoverable; the full local a11y wrapper run completed with 45 passing checks and 4 explicit product-defect skips.
- Keeps the deletion work safe: no old test assets are deleted in this PR, and the deletion/mutating-coverage/further-coverage work is split into dedicated follow-on tickets.

### Testing done

Automated:

- [x] `yarn lint` - passed
- [x] `yarn lint:playwright:architecture` - passed
- [x] `PLAYWRIGHT_SKIP_INSTALL=true yarn test:api:pw:raw playwright_tests_new/api/unit/reporting-scripts.unit.api.ts playwright_tests_new/api/unit/retirement-scripts.unit.api.ts` - 10 passed
- [x] `PLAYWRIGHT_SKIP_INSTALL=true PLAYWRIGHT_EXCLUDE_TAGS=@a11y yarn test:a11y:playwright -- --list` - listed 47 E2E a11y tests and 2 integration a11y tests
- [x] `FUNCTIONAL_TESTS_WORKERS=4 PLAYWRIGHT_SKIP_INSTALL=true yarn test:a11y:playwright` - 45 passed, 4 skipped for known product defects
- [x] `node scripts/run-playwright-a11y.js --grep @registration` - failed fast as expected
- [x] `node scripts/retired-codecept-runner.js bridge test:api` - failed fast as expected
- [x] `yarn test:coverage:node` - 147 passing, 6 pending; statements 85.8%, branches 75.22%, functions 77.61%, lines 86.02%
- [x] `yarn npm audit --recursive --environment production --json > yarn-audit-known-issues` - exited 1 with known advisories, 57 JSON audit lines parsed, no file diff

Manual:

- [x] Verified branch diff is limited to pipeline/test-runner hardening and API unit coverage.
- [x] Verified generated a11y report paths are present locally.

Evidence:

- HTML: `functional-output/tests/playwright-a11y/html-report/index.html`
- HTML: `functional-output/tests/playwright-a11y/integration/html-report/index.html`
- Odhín: `functional-output/tests/playwright-a11y/odhin-report/xui-playwright-a11y.html`
- Odhín: `functional-output/tests/playwright-a11y/integration/odhin-report/xui-playwright-a11y-integration.html`
- JUnit: `functional-output/tests/playwright-a11y/playwright-a11y-junit.xml`
- JUnit: `functional-output/tests/playwright-a11y/integration/playwright-a11y-integration-junit.xml`

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
