### PR TITLE
EXUI-4644/EXUI-4645: Add cleanup-safe API coverage

### DIFF
--- a/playwright_tests_new/api/case-sharing.api.ts
+++ b/playwright_tests_new/api/case-sharing.api.ts
@@ -1,0 +1,25 @@
+import { test, expect } from './fixtures';
+import type { CaseShareUser } from './utils/types';
+
+test.describe('Case sharing API contracts', { tag: '@svc-case-sharing' }, () => {
+  test('returns active case-share users with mapped IDAM identity fields', async ({ apiClient }) => {
+    const response = await apiClient.get<CaseShareUser[]>('api/caseshare/users');
+    const users = response.data;
+    const identifiableUser = users.find((user) => user.email && user.firstName && user.idamId && user.lastName);
+
+    expect(response.status, 'Case-share users should be returned for an authenticated user').toBe(200);
+    expect(users, 'Case-share users response should be an array').toEqual(expect.any(Array));
+    expect(users.length, 'At least one active user should be available for case sharing').toBeGreaterThan(0);
+    expect(identifiableUser, 'At least one case-share user should include mapped identity fields').toEqual(
+      expect.objectContaining({
+        email: expect.stringMatching(/^[^@\s]+@[^@\s]+\.[^@\s]+$/),
+        firstName: expect.any(String),
+        idamId: expect.any(String),
+        lastName: expect.any(String)
+      })
+    );
+    expect(identifiableUser?.firstName, 'Mapped case-share user first name should not be empty').not.toHaveLength(0);
+    expect(identifiableUser?.idamId, 'Mapped case-share user IDAM identifier should not be empty').not.toHaveLength(0);
+    expect(identifiableUser?.lastName, 'Mapped case-share user last name should not be empty').not.toHaveLength(0);
+  });
+});

--- a/playwright_tests_new/api/cleanup-safe-mutating.api.ts
+++ b/playwright_tests_new/api/cleanup-safe-mutating.api.ts
@@ -1,0 +1,54 @@
+import { test, expect } from './fixtures';
+import type { MutatingApiResult, OrganisationDetailsResponse } from './utils/types';
+
+const noSelectedCasesPayload = {
+  sharedCases: []
+};
+
+const noPaymentAccountChangesPayload = {
+  pendingPaymentAccount: {
+    pendingAddPaymentAccount: [],
+    pendingRemovePaymentAccount: []
+  }
+};
+
+test.describe('Cleanup-safe mutating API contracts', { tag: '@svc-mutating-api' }, () => {
+  test('accepts a case-share assignment submission with no selected cases without changing case assignments', async ({
+    apiClient,
+    xsrfHeaders
+  }) => {
+    const response = await apiClient.post<[]>('api/caseshare/case-assignments', {
+      data: noSelectedCasesPayload,
+      headers: xsrfHeaders
+    });
+
+    expect(response.status, 'No-op case-share assignment submissions should be accepted').toBe(201);
+    expect(response.data, 'No selected cases should produce an empty assignment result').toEqual([]);
+  });
+
+  test('accepts a PBA add-delete submission with no account changes and keeps organisation accounts unchanged', async ({
+    apiClient,
+    xsrfHeaders
+  }) => {
+    const beforeResponse = await apiClient.get<OrganisationDetailsResponse>('api/organisation');
+    const beforeAccounts = beforeResponse.data.paymentAccount ?? [];
+
+    const updateResponse = await apiClient.post<MutatingApiResult>('api/pba/addDeletePBA', {
+      data: noPaymentAccountChangesPayload,
+      headers: xsrfHeaders
+    });
+
+    const afterResponse = await apiClient.get<OrganisationDetailsResponse>('api/organisation');
+
+    expect(beforeResponse.status, 'Organisation details should be available before the no-op PBA update').toBe(200);
+    expect(updateResponse.status, 'No-op PBA add-delete submissions should complete through the mutation route').toBe(202);
+    expect(updateResponse.data, 'No-op PBA add-delete response should use the existing delete-only success contract').toEqual({
+      code: 202,
+      message: 'delete successfully'
+    });
+    expect(afterResponse.status, 'Organisation details should be available after the no-op PBA update').toBe(200);
+    expect(afterResponse.data.paymentAccount ?? [], 'No-op PBA update should not change organisation payment accounts').toEqual(
+      beforeAccounts
+    );
+  });
+});

--- a/playwright_tests_new/api/fee-accounts.api.ts
+++ b/playwright_tests_new/api/fee-accounts.api.ts
@@ -1,0 +1,29 @@
+import { test, expect } from './fixtures';
+import type { FeeAccount, OrganisationDetailsResponse } from './utils/types';
+
+test.describe('Fee account API contracts', { tag: '@svc-fee-accounts' }, () => {
+  test('returns fee account details for an organisation payment account when one is configured', async ({ apiClient }) => {
+    const organisationResponse = await apiClient.get<OrganisationDetailsResponse>('api/organisation');
+    const paymentAccount = organisationResponse.data.paymentAccount?.find((account) => /^PBA\d+$/.test(account));
+
+    expect(organisationResponse.status, 'Organisation details should be returned before fee account lookup').toBe(200);
+    test.skip(!paymentAccount, 'The configured organisation has no PBA account to look up.');
+
+    const response = await apiClient.get<FeeAccount[]>(`api/accounts?accountNames=${paymentAccount}`, {
+      throwOnError: false
+    });
+    const [account] = response.data;
+
+    expect([200, 404], 'Fee account lookup should return either account details or the existing missing-account contract').toContain(
+      response.status
+    );
+    expect(response.data, 'Fee account lookup response should be an array').toEqual(expect.any(Array));
+    expect(response.data.length, 'Fee account lookup should return one account result for one account request').toBe(1);
+    expect(account, 'Fee account response should preserve the requested account number and balance shape').toEqual(
+      expect.objectContaining({
+        account_number: paymentAccount,
+        available_balance: expect.any(Number)
+      })
+    );
+  });
+});

--- a/playwright_tests_new/api/guard-rails.api.ts
+++ b/playwright_tests_new/api/guard-rails.api.ts
@@ -17,6 +17,13 @@ const pbaPayload = {
   pbaNumber: 'PBA0000000'
 };
 
+const pbaAddDeletePayload = {
+  pendingPaymentAccount: {
+    pendingAddPaymentAccount: [],
+    pendingRemovePaymentAccount: []
+  }
+};
+
 test.describe('Protected API guard rail contracts', { tag: '@svc-auth-guards' }, () => {
   test('rejects anonymous organisation user requests', async ({ anonymousClient }) => {
     const response = await anonymousClient.get('api/organisation/users', { throwOnError: false });
@@ -107,5 +114,26 @@ test.describe('Protected API guard rail contracts', { tag: '@svc-auth-guards' },
     });
 
     expect([401, 403], 'Anonymous PBA delete requests should be rejected').toContain(response.status);
+  });
+
+  test('rejects anonymous PBA add-delete requests before payload processing', async ({ anonymousClient }) => {
+    const response = await anonymousClient.post('api/pba/addDeletePBA', {
+      data: pbaAddDeletePayload,
+      throwOnError: false
+    });
+
+    expect([401, 403], 'Anonymous PBA add-delete requests should be rejected').toContain(response.status);
+  });
+
+  test('rejects anonymous fee account lookup requests', async ({ anonymousClient }) => {
+    const response = await anonymousClient.get('api/accounts?accountNames=PBA0000000', { throwOnError: false });
+
+    expect([401, 403], 'Anonymous fee account lookup requests should be rejected').toContain(response.status);
+  });
+
+  test('rejects anonymous payment history lookup requests', async ({ anonymousClient }) => {
+    const response = await anonymousClient.get('api/payments/PBA0000000', { throwOnError: false });
+
+    expect([401, 403], 'Anonymous payment history lookup requests should be rejected').toContain(response.status);
   });
 });

--- a/playwright_tests_new/api/user-list.api.ts
+++ b/playwright_tests_new/api/user-list.api.ts
@@ -85,4 +85,10 @@ test.describe('User list API contracts', { tag: '@svc-user-admin' }, () => {
 
     expect([401, 403], 'Anonymous full user list requests should be rejected').toContain(response.status);
   });
+
+  test('rejects anonymous full user list with roles requests', async ({ anonymousClient }) => {
+    const response = await anonymousClient.get('api/allUserList', { throwOnError: false });
+
+    expect([401, 403], 'Anonymous full user list with roles requests should be rejected').toContain(response.status);
+  });
 });

--- a/playwright_tests_new/api/utils/types.ts
+++ b/playwright_tests_new/api/utils/types.ts
@@ -7,6 +7,14 @@ export type ManageOrgUser = {
   userIdentifier?: string;
 };
 
+export type CaseShareUser = {
+  caseRoles?: string[];
+  email?: string;
+  firstName?: string;
+  idamId?: string;
+  lastName?: string;
+};
+
 export type DxAddress = {
   dxExchange?: string;
   dxNumber?: string;
@@ -28,6 +36,20 @@ export type OrganisationDetailsResponse = {
   sraId?: string;
   sraRegulated?: boolean;
   status?: string;
+};
+
+export type FeeAccount = {
+  account_name?: string | null;
+  account_number?: string;
+  available_balance?: number;
+  credit_limit?: number | null;
+  effective_date?: string;
+  status?: string | null;
+};
+
+export type MutatingApiResult = {
+  code?: number;
+  message?: string;
 };
 
 export type ReferenceItem = {


### PR DESCRIPTION
### Jira link

See [EXUI-4644](https://tools.hmcts.net/jira/browse/EXUI-4644) and [EXUI-4645](https://tools.hmcts.net/jira/browse/EXUI-4645)

### Change description ###

- Adds Playwright API coverage for cleanup-safe mutating Manage Org API routes.
- Adds stable read-side coverage for case-share users and fee-account lookup.
- Expands API auth guard coverage for previously uncovered protected routes.
- Keeps production implementation untouched; this is test-only.

### Value added to our test pack by delivering this ticket

- Brings safe default CI coverage to mutation handlers that were previously either untested or only covered through old framework paths.
- Proves `api/caseshare/case-assignments` handles an empty selected-cases mutation as a no-op.
- Proves `api/pba/addDeletePBA` handles empty add/remove PBA changes as a no-op and leaves organisation payment accounts unchanged.
- Covers the live case-share user mapping contract used by Manage Org case-sharing journeys.
- Covers fee-account lookup from the organisation’s configured PBA account, including the existing missing-account response shape.
- Adds missing anonymous guard checks for combined PBA mutation, fee account lookup, payment history lookup, and full user-list-with-roles.
- Documents two rejected positive candidates from AAT evidence: `api/termsAndConditions` currently returns 502 and `api/allUserList` currently returns 500, so they are not introduced as flaky CI tests.

### Testing done

Automated:

- [x] `yarn lint:playwright:api` - passed
- [x] `PLAYWRIGHT_SKIP_INSTALL=true yarn test:api:pw:raw playwright_tests_new/api/cleanup-safe-mutating.api.ts playwright_tests_new/api/case-sharing.api.ts playwright_tests_new/api/fee-accounts.api.ts playwright_tests_new/api/user-list.api.ts playwright_tests_new/api/terms-and-conditions.api.ts playwright_tests_new/api/guard-rails.api.ts` - 26 passed
- [x] `PLAYWRIGHT_SKIP_INSTALL=true yarn test:api:pw:raw` - 64 passed, 2 skipped
- [x] `yarn lint` - passed

Manual:

- [x] Reviewed the diff for production-code drift. No `src` or application API implementation files changed.

Evidence:

- HTML: N/A
- Odhín: `functional-output/tests/playwright-api/odhin-report/xui-mo-playwright-api.html`
- JUnit: N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
