### PR TITLE
EXUI-4644: Add cleanup-safe API coverage

### DIFF
--- a/playwright_tests_new/api/cleanup-safe-mutating.api.ts
+++ b/playwright_tests_new/api/cleanup-safe-mutating.api.ts
@@ -1,0 +1,54 @@
+import { test, expect } from './fixtures';
+import type { MutatingApiResult, OrganisationDetailsResponse } from './utils/types';
+
+const noSelectedCasesPayload = {
+  sharedCases: []
+};
+
+const noPaymentAccountChangesPayload = {
+  pendingPaymentAccount: {
+    pendingAddPaymentAccount: [],
+    pendingRemovePaymentAccount: []
+  }
+};
+
+test.describe('Cleanup-safe mutating API contracts', { tag: '@svc-mutating-api' }, () => {
+  test('accepts a case-share assignment submission with no selected cases and returns an empty result', async ({
+    apiClient,
+    xsrfHeaders
+  }) => {
+    const response = await apiClient.post<[]>('api/caseshare/case-assignments', {
+      data: noSelectedCasesPayload,
+      headers: xsrfHeaders
+    });
+
+    expect(response.status, 'No-op case-share assignment submissions should be accepted').toBe(201);
+    expect(response.data, 'No selected cases should produce an empty assignment result').toEqual([]);
+  });
+
+  test('accepts a PBA add-delete submission with no account changes and keeps organisation accounts unchanged', async ({
+    apiClient,
+    xsrfHeaders
+  }) => {
+    const beforeResponse = await apiClient.get<OrganisationDetailsResponse>('api/organisation');
+    const beforeAccounts = beforeResponse.data.paymentAccount ?? [];
+
+    const updateResponse = await apiClient.post<MutatingApiResult>('api/pba/addDeletePBA', {
+      data: noPaymentAccountChangesPayload,
+      headers: xsrfHeaders
+    });
+
+    const afterResponse = await apiClient.get<OrganisationDetailsResponse>('api/organisation');
+
+    expect(beforeResponse.status, 'Organisation details should be available before the no-op PBA update').toBe(200);
+    expect(updateResponse.status, 'No-op PBA add-delete submissions should complete through the mutation route').toBe(202);
+    expect(updateResponse.data, 'No-op PBA add-delete response should use the existing delete-only success contract').toEqual({
+      code: 202,
+      message: 'delete successfully'
+    });
+    expect(afterResponse.status, 'Organisation details should be available after the no-op PBA update').toBe(200);
+    expect(afterResponse.data.paymentAccount ?? [], 'No-op PBA update should not change organisation payment accounts').toEqual(
+      beforeAccounts
+    );
+  });
+});

--- a/playwright_tests_new/api/guard-rails.api.ts
+++ b/playwright_tests_new/api/guard-rails.api.ts
@@ -17,6 +17,13 @@ const pbaPayload = {
   pbaNumber: 'PBA0000000'
 };
 
+const pbaAddDeletePayload = {
+  pendingPaymentAccount: {
+    pendingAddPaymentAccount: [],
+    pendingRemovePaymentAccount: []
+  }
+};
+
 test.describe('Protected API guard rail contracts', { tag: '@svc-auth-guards' }, () => {
   test('rejects anonymous organisation user requests', async ({ anonymousClient }) => {
     const response = await anonymousClient.get('api/organisation/users', { throwOnError: false });
@@ -107,5 +114,14 @@ test.describe('Protected API guard rail contracts', { tag: '@svc-auth-guards' },
     });
 
     expect([401, 403], 'Anonymous PBA delete requests should be rejected').toContain(response.status);
+  });
+
+  test('rejects anonymous PBA add-delete requests before payload processing', async ({ anonymousClient }) => {
+    const response = await anonymousClient.post('api/pba/addDeletePBA', {
+      data: pbaAddDeletePayload,
+      throwOnError: false
+    });
+
+    expect([401, 403], 'Anonymous PBA add-delete requests should be rejected').toContain(response.status);
   });
 });

--- a/playwright_tests_new/api/utils/types.ts
+++ b/playwright_tests_new/api/utils/types.ts
@@ -30,6 +30,11 @@ export type OrganisationDetailsResponse = {
   status?: string;
 };
 
+export type MutatingApiResult = {
+  code?: number;
+  message?: string;
+};
+
 export type ReferenceItem = {
   id?: string;
   [key: string]: unknown;


### PR DESCRIPTION
### Jira link

See [EXUI-4644](https://tools.hmcts.net/jira/browse/EXUI-4644)

### Change description ###

- Adds cleanup-safe Playwright API coverage for no-op mutating Manage Org API routes.
- Verifies empty case-share assignment submissions return the existing empty result contract.
- Verifies empty PBA add/delete submissions complete without changing organisation payment accounts.
- Adds the directly related anonymous guard coverage for `api/pba/addDeletePBA`.
- Keeps production implementation untouched; this is test-only.

### Value added to our test pack by delivering this ticket

- Gives CI a safe mutation smoke layer without creating or deleting live data.
- Increases confidence that cleanup/default branches of mutation handlers stay stable after retiring the old framework path.
- Proves the PBA no-op mutation preserves organisation payment-account state before and after the request.
- Keeps the PR scoped to one Jira ticket after superseding the combined #1564 branch.

### Testing done

Automated:

- [x] `yarn lint:playwright:api` - passed
- [x] `PLAYWRIGHT_SKIP_INSTALL=true yarn test:api:pw:raw playwright_tests_new/api/cleanup-safe-mutating.api.ts playwright_tests_new/api/guard-rails.api.ts` - 13 passed
- [x] `yarn lint` - passed
- [x] `yarn npm audit --recursive --environment production --json > yarn-audit-known-issues` - exited 1 with known advisories; 57 JSON audit lines parsed; no file diff

Manual:

- [x] Verified PR scope is EXUI-4644 only and does not include the EXUI-4645 read-side expansion.
- [x] Verified no production `src/` files changed.

Evidence:

- Odhín: `functional-output/tests/playwright-api/odhin-report/xui-mo-playwright-api.html`
- JUnit: N/A for focused local API run

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
