### PR TITLE
EXUI-4645: Expand Playwright API coverage

### DIFF
--- a/playwright_tests_new/api/case-sharing.api.ts
+++ b/playwright_tests_new/api/case-sharing.api.ts
@@ -1,0 +1,25 @@
+import { test, expect } from './fixtures';
+import type { CaseShareUser } from './utils/types';
+
+test.describe('Case sharing API contracts', { tag: '@svc-case-sharing' }, () => {
+  test('returns active case-share users with mapped IDAM identity fields', async ({ apiClient }) => {
+    const response = await apiClient.get<CaseShareUser[]>('api/caseshare/users');
+    const users = response.data;
+    const identifiableUser = users.find((user) => user.email && user.firstName && user.idamId && user.lastName);
+
+    expect(response.status, 'Case-share users should be returned for an authenticated user').toBe(200);
+    expect(users, 'Case-share users response should be an array').toEqual(expect.any(Array));
+    expect(users.length, 'At least one active user should be available for case sharing').toBeGreaterThan(0);
+    expect(identifiableUser, 'At least one case-share user should include mapped identity fields').toEqual(
+      expect.objectContaining({
+        email: expect.stringMatching(/^[^@\s]+@[^@\s]+\.[^@\s]+$/),
+        firstName: expect.any(String),
+        idamId: expect.any(String),
+        lastName: expect.any(String)
+      })
+    );
+    expect(identifiableUser?.firstName, 'Mapped case-share user first name should not be empty').not.toHaveLength(0);
+    expect(identifiableUser?.idamId, 'Mapped case-share user IDAM identifier should not be empty').not.toHaveLength(0);
+    expect(identifiableUser?.lastName, 'Mapped case-share user last name should not be empty').not.toHaveLength(0);
+  });
+});

--- a/playwright_tests_new/api/fee-accounts.api.ts
+++ b/playwright_tests_new/api/fee-accounts.api.ts
@@ -1,0 +1,50 @@
+import { test, expect } from './fixtures';
+import type { FeeAccount, OrganisationDetailsResponse } from './utils/types';
+
+const unknownPaymentAccount = 'PBA0000000';
+const missingAccountMessage = 'Account not found';
+
+test.describe('Fee account API contracts', { tag: '@svc-fee-accounts' }, () => {
+  test('returns fee account details for an organisation payment account when the fee account service recognises it', async ({
+    apiClient
+  }) => {
+    const organisationResponse = await apiClient.get<OrganisationDetailsResponse>('api/organisation');
+    const paymentAccount = organisationResponse.data.paymentAccount?.find((account) => /^PBA\d+$/.test(account));
+
+    expect(organisationResponse.status, 'Organisation details should be returned before fee account lookup').toBe(200);
+    test.skip(!paymentAccount, 'The configured organisation has no PBA account to look up.');
+
+    const response = await apiClient.get<FeeAccount[]>(`api/accounts?accountNames=${paymentAccount}`, {
+      throwOnError: false
+    });
+
+    test.skip(
+      response.status === 404,
+      `The configured organisation PBA ${paymentAccount} is not recognised by the fee account service in this environment.`
+    );
+    expect(response.status, 'Recognised organisation payment accounts should return fee account details').toBe(200);
+    expect(response.data, 'Fee account lookup response should be an array').toEqual(expect.any(Array));
+    const [account] = response.data;
+
+    expect(response.data.length, 'Fee account lookup should return one account result for one account request').toBe(1);
+    expect(account, 'Fee account response should preserve the requested account number and balance shape').toEqual(
+      expect.objectContaining({
+        account_number: paymentAccount,
+        available_balance: expect.any(Number)
+      })
+    );
+  });
+
+  test('returns the missing-account contract for an unknown payment account', async ({ apiClient }) => {
+    const response = await apiClient.get<string[]>(`api/accounts?accountNames=${unknownPaymentAccount}`, {
+      throwOnError: false
+    });
+
+    expect(response.status, 'Unknown fee account lookups should use the missing-account status').toBe(404);
+    expect(response.data, 'Missing-account lookup response should be an array').toEqual(expect.any(Array));
+    const [account] = response.data;
+
+    expect(response.data.length, 'Missing-account lookup should return one result for one account request').toBe(1);
+    expect(account, 'Missing-account response should preserve the current node API error message').toBe(missingAccountMessage);
+  });
+});

--- a/playwright_tests_new/api/guard-rails.api.ts
+++ b/playwright_tests_new/api/guard-rails.api.ts
@@ -108,4 +108,16 @@ test.describe('Protected API guard rail contracts', { tag: '@svc-auth-guards' },
 
     expect([401, 403], 'Anonymous PBA delete requests should be rejected').toContain(response.status);
   });
+
+  test('rejects anonymous fee account lookup requests', async ({ anonymousClient }) => {
+    const response = await anonymousClient.get('api/accounts?accountNames=PBA0000000', { throwOnError: false });
+
+    expect([401, 403], 'Anonymous fee account lookup requests should be rejected').toContain(response.status);
+  });
+
+  test('rejects anonymous payment history lookup requests', async ({ anonymousClient }) => {
+    const response = await anonymousClient.get('api/payments/PBA0000000', { throwOnError: false });
+
+    expect([401, 403], 'Anonymous payment history lookup requests should be rejected').toContain(response.status);
+  });
 });

--- a/playwright_tests_new/api/user-list.api.ts
+++ b/playwright_tests_new/api/user-list.api.ts
@@ -85,4 +85,10 @@ test.describe('User list API contracts', { tag: '@svc-user-admin' }, () => {
 
     expect([401, 403], 'Anonymous full user list requests should be rejected').toContain(response.status);
   });
+
+  test('rejects anonymous full user list with roles requests', async ({ anonymousClient }) => {
+    const response = await anonymousClient.get('api/allUserList', { throwOnError: false });
+
+    expect([401, 403], 'Anonymous full user list with roles requests should be rejected').toContain(response.status);
+  });
 });

--- a/playwright_tests_new/api/utils/types.ts
+++ b/playwright_tests_new/api/utils/types.ts
@@ -7,6 +7,14 @@ export type ManageOrgUser = {
   userIdentifier?: string;
 };
 
+export type CaseShareUser = {
+  caseRoles?: string[];
+  email?: string;
+  firstName?: string;
+  idamId?: string;
+  lastName?: string;
+};
+
 export type DxAddress = {
   dxExchange?: string;
   dxNumber?: string;
@@ -28,6 +36,15 @@ export type OrganisationDetailsResponse = {
   sraId?: string;
   sraRegulated?: boolean;
   status?: string;
+};
+
+export type FeeAccount = {
+  account_name?: string | null;
+  account_number?: string;
+  available_balance?: number;
+  credit_limit?: number | null;
+  effective_date?: string;
+  status?: string | null;
 };
 
 export type ReferenceItem = {


### PR DESCRIPTION
### Jira link

See [EXUI-4645](https://tools.hmcts.net/jira/browse/EXUI-4645)

### Change description ###

- Adds read-side Playwright API coverage for case-share users and fee-account lookup.
- Adds explicit fee-account missing-account coverage for the current node API `Account not found` contract.
- Expands anonymous guard coverage for fee account lookup, payment history lookup, and full user-list-with-roles.
- Keeps production implementation untouched; this is test-only.

### Value added to our test pack by delivering this ticket

- Covers Manage Org API behaviour beyond the legacy retirement parity baseline without relying on old Codecept execution.
- Proves the case-share user mapping contract includes active IDAM identity fields needed by case-sharing journeys.
- Proves recognised organisation PBA lookup returns account detail shape, while unknown PBA lookup has a separate explicit missing-account assertion.
- Adds protected-route checks for previously uncovered API surfaces so anonymous access failures are visible in CI.
- Keeps the PR scoped to one Jira ticket after superseding the combined #1564 branch.

### Testing done

Automated:

- [x] `yarn lint:playwright:api` - passed
- [x] `PLAYWRIGHT_SKIP_INSTALL=true yarn test:api:pw:raw playwright_tests_new/api/case-sharing.api.ts playwright_tests_new/api/fee-accounts.api.ts playwright_tests_new/api/user-list.api.ts playwright_tests_new/api/guard-rails.api.ts` - 22 passed
- [x] `yarn lint` - passed
- [x] `yarn npm audit --recursive --environment production --json > yarn-audit-known-issues` - exited 1 with known advisories; 57 JSON audit lines parsed; no file diff

Manual:

- [x] Verified PR scope is EXUI-4645 only and does not include EXUI-4644 cleanup-safe mutation coverage.
- [x] Verified the previous fee-account `200 or 404` review smell was removed: `404` is now asserted only in a dedicated missing-account test.
- [x] Verified no production `src/` files changed.

Evidence:

- Odhín: `functional-output/tests/playwright-api/odhin-report/xui-mo-playwright-api.html`
- JUnit: N/A for focused local API run

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
