### PR TITLE
fix: restore parallel static and container pipeline

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,7 +11,7 @@ properties([
     ])
 ])
 
-@Library("Infrastructure@DTSPO-30107-jenkins-agents")
+@Library("Infrastructure")
 
 //To enable PACT testing on pipeline uncomment the next line
 import uk.gov.hmcts.contino.AppPipelineDsl

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -10,7 +10,7 @@ properties([
     pipelineTriggers(env.BRANCH_NAME == 'master' ? [cron('H 07 * * 1-5')] : [])
 ])
 
-@Library("Infrastructure@DTSPO-30107-jenkins-agents")
+@Library("Infrastructure")
 
 def type      = "nodejs"
 def product   = "xui"

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -14,7 +14,7 @@ properties([
     ])
 ])
 
-@Library("Infrastructure@DTSPO-30107-jenkins-agents")
+@Library("Infrastructure")
 
 def type      = "nodejs"
 def product   = "xui"


### PR DESCRIPTION
## Summary
- Restore the shared Jenkins `Infrastructure` library reference in all Manage Org Jenkins entrypoints.
- Reverts the pipeline-library selection introduced by `d792c1793`, which flattened `Static checks` and `Container build` into sequential top-level stages.
- Keeps the change scoped to pipeline stage generation; no test commands, deployment gates, Docker settings, or Playwright configuration were changed.

## Evidence
- Good run screenshot: build 244 at `0dfe8c2`, duration 16m 56s, combined `Static checks / Container build` parallel stage.
- Regressed run screenshot: build 246 at `134f8fd`, duration 29m 6s, separate sequential `Static checks` then `Container build` stages.
- `git diff 0dfe8c2 134f8fd54 -- Jenkinsfile_CNP Jenkinsfile_nightly Jenkinsfile_parameterized` shows the shared library reference was the only Jenkinsfile change between those commits.

## Validation
- `git diff --check`
- `rg -n '@Library\("Infrastructure' Jenkinsfile_CNP Jenkinsfile_nightly Jenkinsfile_parameterized`
- `yarn npm audit --recursive --environment production --json > yarn-audit-known-issues` exited `1` as expected for existing advisories.
- Validated `yarn-audit-known-issues` as JSON-lines: 74 JSON lines, no file diff.

## AI assistance
- Codex assisted with repository inspection, diff analysis, implementation, and validation evidence packaging.

## Residual risk
- The generated Jenkins visual stage layout cannot be fully proven locally; final proof is the PR Jenkins run showing the combined parallel `Static checks / Container build` stage again.