### PR TITLE
EXUI-4836: improve Odhín report navigation

### DIFF
--- a/playwright_tests_new/E2E/utils/accessibility/waveLikeAccessibility.ts
+++ b/playwright_tests_new/E2E/utils/accessibility/waveLikeAccessibility.ts
@@ -288,6 +288,8 @@ export async function attachWaveLikeAccessibilityEvidence(
 
 function buildIssueSummaryHtml(url: string, violations: WaveLikeViolation[]): string {
   const hasViolations = violations.length > 0;
+  const odhinIndexFileName = process.env.PLAYWRIGHT_REPORT_INDEX_FILENAME || 'xui-playwright-accessibility.html';
+  const odhinReportHref = `../${escapeHtml(odhinIndexFileName)}`;
   const cards = violations
     .map(
       (violation, index) => `
@@ -311,6 +313,8 @@ function buildIssueSummaryHtml(url: string, violations: WaveLikeViolation[]): st
           .banner { background: ${hasViolations ? '#d4351c' : '#00703c'}; color: #fff; padding: 16px; margin-bottom: 24px; }
           .issue { border: 4px solid #d4351c; padding: 16px; margin-bottom: 18px; }
           .issue h2 { margin-top: 0; }
+          .report-nav { margin: 0 0 18px; }
+          .report-nav a { color: #1d70b8; font-weight: bold; }
           .advice { background: #f3f2f1; border-left: 8px solid #1d70b8; padding: 12px 16px; margin: 12px 0; }
           .advice dt { font-weight: bold; margin-top: 8px; }
           .advice dd { margin-left: 0; }
@@ -322,7 +326,9 @@ function buildIssueSummaryHtml(url: string, violations: WaveLikeViolation[]): st
           <h1>${hasViolations ? 'WAVE-LIKE ACCESSIBILITY ISSUES FOUND' : 'NO WAVE-LIKE ACCESSIBILITY ISSUES FOUND'}</h1>
           <p>${violations.length} issue(s) on ${escapeHtml(url)}.${hasViolations ? ' Match marker numbers here to the highlighted screenshot.' : ' Screenshot captured for page-state evidence.'}</p>
         </div>
+        <p class="report-nav"><a href="${odhinReportHref}">Back to Odhín report</a></p>
         ${cards}
+        <p class="report-nav"><a href="${odhinReportHref}">Back to Odhín report</a></p>
       </body>
     </html>
   `;

--- a/playwright_tests_new/api/unit/reporting-scripts.unit.api.ts
+++ b/playwright_tests_new/api/unit/reporting-scripts.unit.api.ts
@@ -313,9 +313,14 @@ test.describe('Manage Org Playwright reporting scripts', { tag: '@svc-internal' 
       expect(html).toContain('Issue Summary');
       expect(html).toContain('Screen-reader issue(s): skip-link');
       expect(html).toContain('likely shared app shell fix');
+      expect(html).toContain(
+        '<a class="issue-link" href="./accessibility-state-wave-accessibility-issues.html" target="_blank" rel="noopener noreferrer">accessibility state</a>'
+      );
       expect(html).toContain('accessibility state');
       expect(html).toContain('1 WAVE-like rule issue(s): skip-link');
-      expect(html).toContain('accessibility-state-wave-accessibility-issues-highlighted-screenshot.png');
+      expect(html).toContain(
+        '<a href="./accessibility-state-wave-accessibility-issues-highlighted-screenshot.png" target="_blank" rel="noopener noreferrer">screenshot</a>'
+      );
     } finally {
       fs.rmSync(rootDir, { recursive: true, force: true });
     }
@@ -341,6 +346,8 @@ test.describe('Manage Org Playwright reporting scripts', { tag: '@svc-internal' 
     expect(html).toContain('var defaultPageLength = 100');
     expect(html).toContain('pageLength: defaultPageLength');
     expect(html).toContain('lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, \'All\']]');
+    expect(html).toContain('stateDuration: -1');
+    expect(html).toContain('stateSave: true');
 
     const emptySuiteHtml = odhinReportEnhancer.__test__.enhanceDashboardHtml(
       '<html><head></head><body><table class="dataTable"></table></body></html>',

--- a/playwright_tests_new/api/unit/wave-like-accessibility.unit.api.ts
+++ b/playwright_tests_new/api/unit/wave-like-accessibility.unit.api.ts
@@ -105,7 +105,9 @@ test.describe('WAVE-like accessibility tag contract', { tag: '@svc-internal' }, 
 
       const html = attachments['wave-accessibility-issues.html'];
       const json = fs.readFileSync(path.join(evidenceDir, 'issue-state-wave-accessibility-issues.json'), 'utf8');
+      const odhinIndexFileName = process.env.PLAYWRIGHT_REPORT_INDEX_FILENAME || 'xui-playwright-accessibility.html';
       expect(html).toContain('Developer advice');
+      expect(html).toContain(`<a href="../${odhinIndexFileName}">Back to Odhín report</a>`);
       expect(html).toContain('What to fix');
       expect(html).toContain('Fix path');
       expect(html).toContain('search selector #continue');

--- a/playwright_tests_new/common/reporters/odhin-report-enhancer.cjs
+++ b/playwright_tests_new/common/reporters/odhin-report-enhancer.cjs
@@ -292,7 +292,9 @@ function injectDataTableDefaults(root) {
       if (jq.fn.dataTable.defaults) {
         jq.extend(true, jq.fn.dataTable.defaults, {
           pageLength: defaultPageLength,
-          lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'All']]
+          lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'All']],
+          stateDuration: -1,
+          stateSave: true
         });
       }
 

--- a/scripts/build-playwright-evidence-dashboard.js
+++ b/scripts/build-playwright-evidence-dashboard.js
@@ -156,11 +156,11 @@ function buildWaveLikeEvidenceIndex(rootDir) {
     .map(
       (entry) => `
         <li>
-          <a class="issue-link" href="./${escapeHtml(entry.htmlFileName)}">${escapeHtml(entry.testTitle)}</a>
+          <a class="issue-link" href="./${escapeHtml(entry.htmlFileName)}" target="_blank" rel="noopener noreferrer">${escapeHtml(entry.testTitle)}</a>
           <p>${entry.violationCount} WAVE-like rule issue(s): ${escapeHtml(entry.rules.join(', ') || 'none')}</p>
-          <a href="./${escapeHtml(entry.screenshotFileName)}">screenshot</a>
+          <a href="./${escapeHtml(entry.screenshotFileName)}" target="_blank" rel="noopener noreferrer">screenshot</a>
           |
-          <a href="./${escapeHtml(entry.jsonFileName)}">DOM and WAVE-like JSON</a>
+          <a href="./${escapeHtml(entry.jsonFileName)}" target="_blank" rel="noopener noreferrer">DOM and WAVE-like JSON</a>
         </li>`
     )
     .join('\n');


### PR DESCRIPTION
## Summary
- add back links from WAVE-like issue detail pages to the active Odhín report
- open WAVE evidence index links in a new tab so the index position is not lost
- enable DataTables state saving in enhanced Odhín reports

## Validation
- node --check scripts/build-playwright-evidence-dashboard.js
- node --check playwright_tests_new/common/reporters/odhin-report-enhancer.cjs
- yarn test:api:pw -- playwright_tests_new/api/unit/reporting-scripts.unit.api.ts playwright_tests_new/api/unit/wave-like-accessibility.unit.api.ts
- git diff --check
- yarn lint
- yarn npm audit --recursive --environment production --json > yarn-audit-known-issues (exits 1 with 18 valid JSON advisory lines; audit evidence unchanged)

AI assistance used: OpenAI Codex supported implementation and validation; human review required before merge.