### PR TITLE
EXUI-4850 Keep nightly accessibility non-blocking

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -374,21 +374,24 @@ withNightlyPipeline(type, product, component) {
                     },
                     playwrightAccessibility: {
                         stage('Playwright Accessibility Tests') {
-                            try {
-                                withEnv(playwrightBrowsersEnv() + [
-                                    "FUNCTIONAL_TESTS_WORKERS=6",
-                                    "PLAYWRIGHT_TEST_OUTPUT_DIR=test-results/playwright-accessibility",
-                                    "PLAYWRIGHT_JUNIT_OUTPUT=${playwrightAccessibilityOutputRoot}/playwright-accessibility-junit.xml",
-                                    "PW_SESSION_CAPTURE_FAILURE_TTL_MS=0",
-                                    "PLAYWRIGHT_SKIP_INSTALL=true"
-                                ]) {
-                                    yarnBuilder.yarn('test:accessibility:playwright')
+                            catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+                                try {
+                                    withEnv(playwrightBrowsersEnv() + [
+                                        "FUNCTIONAL_TESTS_WORKERS=6",
+                                        "PLAYWRIGHT_TEST_OUTPUT_DIR=test-results/playwright-accessibility",
+                                        "PLAYWRIGHT_JUNIT_OUTPUT=${playwrightAccessibilityOutputRoot}/playwright-accessibility-junit.xml",
+                                        "PW_SESSION_CAPTURE_FAILURE_TTL_MS=0",
+                                        "PLAYWRIGHT_SKIP_INSTALL=true"
+                                    ]) {
+                                        yarnBuilder.yarn('test:accessibility:playwright')
+                                    }
+                                } catch (Exception e) {
+                                    echo "[parallel-report-gathering] Playwright Accessibility failed but is non-blocking: ${e.getClass().getName()}: ${e.getMessage()}"
+                                    if (handleParallelInterruption(e)) { return }
+                                    throw e
+                                } finally {
+                                    publishPlaywrightAccessibilityReport('Nightly Manage Org Playwright Accessibility')
                                 }
-                            } catch (Exception e) {
-                                echo "[parallel-report-gathering] Playwright Accessibility failed but is non-blocking: ${e.getClass().getName()}: ${e.getMessage()}"
-                                if (handleParallelInterruption(e)) { return }
-                            } finally {
-                                publishPlaywrightAccessibilityReport('Nightly Manage Org Playwright Accessibility')
                             }
                         }
                     },

--- a/playwright_tests_new/api/unit/playwright-architecture.unit.api.ts
+++ b/playwright_tests_new/api/unit/playwright-architecture.unit.api.ts
@@ -138,6 +138,16 @@ test.describe('Manage Org Playwright architecture guard', { tag: '@svc-internal'
     }, /Jenkinsfile_CNP: missing required Playwright JUnit evidence contract E2E JUnit publication/);
   });
 
+  test('rejects nightly accessibility failures that can mark the full pipeline failed', () => {
+    expectGuardFailure((rootDir) => {
+      const pipelinePath = path.join(rootDir, 'Jenkinsfile_nightly');
+      fs.writeFileSync(
+        pipelinePath,
+        fs.readFileSync(pipelinePath, 'utf8').replace('catchError(buildResult: \'SUCCESS\', stageResult: \'UNSTABLE\')', '')
+      );
+    }, /Jenkinsfile_nightly: missing required Playwright pipeline behavior contract non-blocking nightly accessibility branch/);
+  });
+
   test('rejects missing parameterized shared JUnit publisher', () => {
     expectGuardFailure((rootDir) => {
       const pipelinePath = path.join(rootDir, 'Jenkinsfile_parameterized');

--- a/playwright_tests_new/api/utils/architecture-guard-fixture.ts
+++ b/playwright_tests_new/api/utils/architecture-guard-fixture.ts
@@ -80,7 +80,20 @@ export const createArchitectureGuardFixture = (): string => {
       'publishPlaywrightJUnit(\'functional-output/tests/playwright-api/**/*junit.xml\')',
       'publishPlaywrightJUnit(\'functional-output/tests/playwright-integration/**/*junit.xml\')',
       'publishPlaywrightJUnit(\'functional-output/tests/playwright-accessibility/**/*junit.xml\')',
-      'publishPlaywrightJUnit(\'functional-output/tests/playwright-e2e/**/*junit.xml\')'
+      'publishPlaywrightJUnit(\'functional-output/tests/playwright-e2e/**/*junit.xml\')',
+      'playwrightAccessibility: {',
+      '  stage(\'Playwright Accessibility Tests\') {',
+      '    catchError(buildResult: \'SUCCESS\', stageResult: \'UNSTABLE\') {',
+      '      try {',
+      '        yarnBuilder.yarn(\'test:accessibility:playwright\')',
+      '      } catch (Exception e) {',
+      '        throw e',
+      '      } finally {',
+      '        publishPlaywrightAccessibilityReport(\'Nightly Manage Org Playwright Accessibility\')',
+      '      }',
+      '    }',
+      '  }',
+      '}'
     ].join('\n')
   );
 

--- a/scripts/check-playwright-architecture.js
+++ b/scripts/check-playwright-architecture.js
@@ -70,6 +70,18 @@ const activePipelineFiles = [
   'Jenkinsfile_parameterized'
 ];
 const parameterizedPipelineFile = 'Jenkinsfile_parameterized';
+const requiredPipelineBehaviorContracts = [
+  {
+    fileName: 'Jenkinsfile_nightly',
+    contracts: [
+      {
+        label: 'non-blocking nightly accessibility branch',
+        pattern:
+          /playwrightAccessibility:\s*\{[\s\S]*?stage\(['"]Playwright Accessibility Tests['"]\)\s*\{[\s\S]*?catchError\(buildResult:\s*['"]SUCCESS['"],\s*stageResult:\s*['"]UNSTABLE['"]\)\s*\{[\s\S]*?yarnBuilder\.yarn\(['"]test:accessibility:playwright['"]\)[\s\S]*?throw e[\s\S]*?publishPlaywrightAccessibilityReport\(['"]Nightly Manage Org Playwright Accessibility['"]\)/
+      }
+    ]
+  }
+];
 const requiredPipelineJunitContracts = [
   {
     fileName: 'Jenkinsfile_CNP',
@@ -290,6 +302,15 @@ for (const { fileName, contracts } of requiredPipelineJunitContracts) {
   for (const { pattern, label } of contracts) {
     if (!pattern.test(pipelineSource)) {
       failures.push(`${fileName}: missing required Playwright JUnit evidence contract ${label}.`);
+    }
+  }
+}
+
+for (const { fileName, contracts } of requiredPipelineBehaviorContracts) {
+  const pipelineSource = readFileSync(join(root, fileName), 'utf-8');
+  for (const { pattern, label } of contracts) {
+    if (!pattern.test(pipelineSource)) {
+      failures.push(`${fileName}: missing required Playwright pipeline behavior contract ${label}.`);
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1611 for the Manage Org nightly build #1336 failure:

- keeps the nightly Playwright accessibility pack report-only at the Jenkins stage level
- wraps the nightly `playwrightAccessibility` branch with `catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE')`
- still publishes Odhín/HTML/JUnit/stable artifacts from the accessibility run
- adds an architecture guard and unit fixture check so this non-blocking contract is not accidentally removed

## Value added

Nightly build 1336 proved the runner was already behaving as report-only: the accessibility command returned non-zero because real accessibility defects were found, and it logged that report-only mode keeps this non-blocking unless `A11Y_STRICT=true` is set. Jenkins still failed the full nightly because the parallel branch result was not explicitly routed through a non-blocking `catchError` wrapper.

This PR fixes the pipeline result handling without hiding the accessibility problems. The accessibility report, JUnit, Odhín report, and stable failure artifacts are still published, so defects such as the `/users` page WAVE-like `h1` issue remain visible for follow-up. The only change is that report-only accessibility failures mark the accessibility stage unstable while allowing the nightly to continue. Real interruptions still use the existing interruption handler.

## Evidence

Jenkins nightly build 1336:

- accessibility status counts: 70 passed, 21 failed, 2 skipped
- runner logged: report-only mode keeps this non-blocking unless `A11Y_STRICT=true`
- reports and JUnit were published
- Jenkins still ended `Finished: FAILURE`

Local validation on a clean branch from current `origin/master`:

- `git diff --check origin/master...HEAD`
- `yarn lint:playwright:architecture`
- `yarn lint:playwright:api`
- `yarn lint:prettier`
- `PLAYWRIGHT_SKIP_INSTALL=true npx playwright test playwright_tests_new/api/unit/playwright-architecture.unit.api.ts --project=node-api` - 14 passed

## Review

No product code changed. Scope is limited to nightly Jenkins result handling and the existing Playwright architecture guard.
