### PR TITLE
fix: prevent S2S bearer token logging

### DIFF
--- a/api/register-org/index.spec.ts
+++ b/api/register-org/index.spec.ts
@@ -58,6 +58,7 @@ describe('register-org index', () => {
 
   it('should post the Register Organisation request and send the returned data in an HTTP response', async () => {
     sinon.stub(s2sTokenGeneration, 'generateS2sToken').resolves('abc123');
+    const consoleLog = sinon.stub(console, 'log');
 
     // Stub the fakeAxiosInstance.post call to return a mock response
     sinon.stub(fakeAxiosInstance, 'post').resolves({ data: 'test' } as AxiosResponse);
@@ -75,6 +76,7 @@ describe('register-org index', () => {
     expect(fakeAxiosInstance.post).to.be.calledWith('apiPath/refdata/internal/v1/organisations',
       { name: 'Test organisation' }, options);
     expect(res.send).to.be.calledWith('test');
+    expect(consoleLog).not.to.have.been.calledWith('abc123');
   });
 
   it('should return an HTTP 500 error response if there is an error generating the S2S token', async () => {

--- a/api/register-org/index.ts
+++ b/api/register-org/index.ts
@@ -27,7 +27,6 @@ export async function handleRegisterOrgRoute(req: Request, res: Response) {
     /**
      * We use the S2S token to set the headers.
      */
-    console.log(s2sToken);
     const url = `${rdProfessionalPath}/refdata/internal/v1/organisations`;
     const options = {
       headers: { ServiceAuthorization: `Bearer ${s2sToken}` }


### PR DESCRIPTION
### Jira link

See [EXUI-5070](https://tools.hmcts.net/jira/browse/EXUI-5070)

### Change description ###

- Remove runtime logging of the complete S2S bearer token from the Manage Organisations registration route.
- Add regression coverage confirming the token remains in the `ServiceAuthorization` header and is not logged.

### Testing done

Automated:

- [x] `yarn lint` — passed.
- [x] `yarn eslint api/register-org/index.ts api/register-org/index.spec.ts --no-cache` — passed.
- [x] Focused Mocha run — 3 tests passed:
  `TS_NODE_FILES=true TS_NODE_TRANSPILE_ONLY=true ../node_modules/.bin/mocha --no-config -r dotenv-extended/config -r ts-node/register -r source-map-support/register register-org/index.spec.ts`
- [x] `yarn npm audit --recursive --environment production --json` — completed; exit 1 due to existing production advisories, including Angular advisories. No audit suppression or dependency change is included.
- [ ] Standard API workspace test script — not run successfully because `yarn --cwd api test register-org/index.spec.ts` cannot resolve the repository's `cross-env` command in this checkout.

Manual:

- [ ] Not applicable; this is a server-side logging change.

Evidence:

- HTML: N/A
- Odhin: N/A
- JUnit: N/A
- Jenkins Fortify release 53944 rerun: required after merge/pipeline execution.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change: No
