### PR TITLE
fix: remove hardcoded Fortify test secret

### DIFF
--- a/config/pacttesting.json
+++ b/config/pacttesting.json
@@ -19,11 +19,6 @@
     "s2s": "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal",
     "termsAndConditions": "http://localhost:8995"
   },
-  "secrets": {
-    "rpx": {
-      "mo-session-secret": "secretSauce"
-    }
-  },
   "jurisdictions": [ "SSCS", "AUTOTEST1", "DIVORCE", "PROBATE", "PUBLICLAW", "bulkscan", "BULKSCAN","IA", "EMPLOYMENT", "CMC" ],
   "feature": {
     "appInsightsEnabled": true,

--- a/test/java/config/fortify-client.properties
+++ b/test/java/config/fortify-client.properties
@@ -1,3 +1,3 @@
 fortify.client.releaseId=53944
 fortify.client.unacceptableSeverity=HIGH
-fortify.exclude.pattern=*.jar|*.zip|*.tar|*.key|*.lock|*.spec.ts|*.spec.js|/build|/.angular|/.cache|/.gradle|/.git|/.github|/.playwright-cli|/.vscode|/.yarn|/.nyc_output|/coverage|/functional-output|/node_modules|/reports|/test|/test-results|/test_codecept|/playwright_tests_new|/dist|/functionalTest|/integrationTest|/e2e
+fortify.exclude.pattern=*.jar|*.zip|*.tar|*.key|*.lock|*.spec.ts|*.spec.js|config/custom-environment-variables.json|/build|/.angular|/.cache|/.gradle|/.git|/.github|/.playwright-cli|/.vscode|/.yarn|/.nyc_output|/coverage|/functional-output|/node_modules|/reports|/test|/test-results|/test_codecept|/playwright_tests_new|/dist|/functionalTest|/integrationTest|/e2e


### PR DESCRIPTION
### Jira link

Pending Jira ticket creation; the authenticated Jira browser session is currently at the login screen.

### Change description ###

- Remove the hardcoded `secretSauce` session secret from Pact test configuration.
- Exclude only `config/custom-environment-variables.json` from Fortify source scanning because its values are environment-variable names, not credentials.
- Preserve the existing `S2S_SECRET` and `SESSION_SECRET` deployment mappings.

### Testing done

Automated:

- [x] `yarn lint`
- [x] `yarn test-pact` — 9 passing
- [x] JSON parsing, Node Config environment mapping probe, and `git diff --check`
- [x] `yarn npm audit --recursive --environment production --json` — valid JSON-lines output; exits 1 on existing advisories
- [ ] Not run: Jenkins Fortify scan — required to confirm the remote HIGH gate

Manual:

- [x] Confirmed the supplied Fortify findings and preserved runtime secret injection.

Evidence:

- HTML: N/A
- Odhin: N/A
- JUnit: N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

The Fortify exclusion is for false-positive environment-variable names only; it does not suppress dependency CVEs.

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
